### PR TITLE
Type check function arguments

### DIFF
--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -94,6 +94,16 @@ fn compile() -> Result<(), ()> {
                                 )
                                 .finish()
                         }
+                        TypeErrorKind::Error(message) => {
+                            Report::build(ReportKind::Error, "scratch.crane", 1)
+                                .with_message("A type error occurred.")
+                                .with_label(
+                                    Label::new(SourceSpan::from(("scratch.crane", span)))
+                                        .with_message(message)
+                                        .with_color(Color::Red),
+                                )
+                                .finish()
+                        }
                     };
 
                     error_report

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -12,15 +12,15 @@ use thin_vec::ThinVec;
 
 use crate::ast::visitor::{walk_expr, Visitor};
 use crate::ast::{
-    Expr, ExprKind, Fn, Ident, Item, ItemKind, Literal, LiteralKind, Module, Span, Stmt, StmtKind,
-    TyExpr, TyExprKind, TyFn, TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteral,
+    Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Module, Span, Stmt,
+    StmtKind, TyExpr, TyExprKind, TyFn, TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteral,
     TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyUint, DUMMY_SPAN,
 };
 
 pub type TypeCheckResult<T> = Result<T, TypeError>;
 
 pub struct Typer {
-    module_functions: HashMap<Ident, ()>,
+    module_functions: HashMap<Ident, ThinVec<TyFnParam>>,
 }
 
 impl Typer {
@@ -32,27 +32,41 @@ impl Typer {
 
     pub fn type_check_module(&mut self, module: Module) -> TypeCheckResult<TyModule> {
         // HACK: Register the functions from `std`.
-        self.register_function(Ident {
-            name: "print".into(),
-            span: DUMMY_SPAN,
-        });
-        self.register_function(Ident {
-            name: "println".into(),
-            span: DUMMY_SPAN,
-        });
-        self.register_function(Ident {
-            name: "int_add".into(),
-            span: DUMMY_SPAN,
-        });
-        self.register_function(Ident {
-            name: "int_to_string".into(),
-            span: DUMMY_SPAN,
-        });
+        self.register_function(
+            Ident {
+                name: "print".into(),
+                span: DUMMY_SPAN,
+            },
+            ThinVec::new(),
+        );
+        self.register_function(
+            Ident {
+                name: "println".into(),
+                span: DUMMY_SPAN,
+            },
+            ThinVec::new(),
+        );
+        self.register_function(
+            Ident {
+                name: "int_add".into(),
+                span: DUMMY_SPAN,
+            },
+            ThinVec::new(),
+        );
+        self.register_function(
+            Ident {
+                name: "int_to_string".into(),
+                span: DUMMY_SPAN,
+            },
+            ThinVec::new(),
+        );
 
         for item in &module.items {
             match item.kind {
-                ItemKind::Fn(_) => {
-                    self.register_function(item.name.clone());
+                ItemKind::Fn(ref fun) => {
+                    let params = self.infer_function_params(&fun.params)?;
+
+                    self.register_function(item.name.clone(), params.clone());
                 }
             }
         }
@@ -76,8 +90,8 @@ impl Typer {
         Ok(TyModule { items: typed_items })
     }
 
-    fn register_function(&mut self, name: Ident) {
-        self.module_functions.insert(name, ());
+    fn register_function(&mut self, name: Ident, params: ThinVec<TyFnParam>) {
+        self.module_functions.insert(name, params);
     }
 
     fn ensure_function_exists(&self, ident: &Ident) -> TypeCheckResult<()> {
@@ -104,24 +118,30 @@ impl Typer {
 
     fn infer_function(&self, fun: Fn) -> TypeCheckResult<TyFn> {
         Ok(TyFn {
-            params: fun
-                .params
-                .iter()
-                .map(|param| TyFnParam {
-                    name: param.name.clone(),
-                    ty: Arc::new(Type::UserDefined {
-                        module: "std::prelude".into(),
-                        name: param.ty.to_string().into(),
-                    }),
-                    span: param.span,
-                })
-                .collect::<ThinVec<_>>(),
+            params: self.infer_function_params(&fun.params)?,
             body: fun
                 .body
                 .into_iter()
                 .map(|stmt| self.infer_stmt(stmt))
                 .collect::<Result<ThinVec<_>, _>>()?,
         })
+    }
+
+    fn infer_function_params(
+        &self,
+        params: &ThinVec<FnParam>,
+    ) -> TypeCheckResult<ThinVec<TyFnParam>> {
+        Ok(params
+            .iter()
+            .map(|param| TyFnParam {
+                name: param.name.clone(),
+                ty: Arc::new(Type::UserDefined {
+                    module: "std::prelude".into(),
+                    name: param.ty.to_string().into(),
+                }),
+                span: param.span,
+            })
+            .collect::<ThinVec<_>>())
     }
 
     fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
@@ -148,21 +168,72 @@ impl Typer {
                 }),
                 span: expr.span,
             }),
-            ExprKind::Call { fun, args } => Ok(TyExpr {
-                kind: TyExprKind::Call {
-                    fun: Box::new(self.infer_expr(*fun)?),
-                    args: args
-                        .into_iter()
-                        .map(|expr| self.infer_expr(*expr))
-                        .map(|result| result.map(Box::new))
-                        .collect::<Result<ThinVec<_>, _>>()?,
-                },
-                ty: Arc::new(Type::UserDefined {
-                    module: "?".into(),
-                    name: "?".into(),
-                }),
-                span: expr.span,
-            }),
+            ExprKind::Call { fun, args } => {
+                let callee = self.infer_expr(*fun.clone())?;
+
+                let callee = match &callee.kind {
+                    TyExprKind::Variable { name } => Ok(name),
+                    _ => Err(TypeError {
+                        kind: TypeErrorKind::Error(format!("Not a function.")),
+                        span: callee.span,
+                    }),
+                }?;
+
+                let callee_params =
+                    self.module_functions
+                        .get(&callee)
+                        .ok_or_else(|| TypeError {
+                            kind: TypeErrorKind::Error(format!("Function `{}` not found.", callee)),
+                            span: callee.span,
+                        })?;
+
+                let caller_args = args
+                    .into_iter()
+                    .map(|expr| self.infer_expr(*expr))
+                    .map(|result| result.map(Box::new))
+                    .collect::<Result<ThinVec<_>, _>>()?;
+
+                for (param, arg) in callee_params.into_iter().zip(&caller_args) {
+                    if param.ty != arg.ty {
+                        fn ty_to_string(ty: &Type) -> String {
+                            match ty {
+                                Type::UserDefined { module, name } => {
+                                    format!("{}::{}", module, name)
+                                }
+                                Type::Fn { args, return_ty } => format!(
+                                    "Fn({}) -> {}",
+                                    args.iter()
+                                        .map(|ty| ty_to_string(ty))
+                                        .collect::<Vec<_>>()
+                                        .join(", "),
+                                    ty_to_string(return_ty)
+                                ),
+                            }
+                        }
+
+                        return Err(TypeError {
+                            kind: TypeErrorKind::Error(format!(
+                                "Expected `{}` but received `{}`",
+                                ty_to_string(&param.ty),
+                                ty_to_string(&arg.ty)
+                            )),
+                            span: arg.span,
+                        });
+                    }
+                }
+
+                Ok(TyExpr {
+                    kind: TyExprKind::Call {
+                        fun: Box::new(self.infer_expr(*fun)?),
+                        args: caller_args,
+                    },
+                    ty: Arc::new(Type::UserDefined {
+                        module: "?".into(),
+                        name: "?".into(),
+                    }),
+                    span: expr.span,
+                })
+            }
         }
     }
 

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -9,4 +9,5 @@ pub struct TypeError {
 #[derive(Debug)]
 pub enum TypeErrorKind {
     UnknownFunction { name: Ident },
+    Error(String),
 }


### PR DESCRIPTION
This PR adds support for type-checking function arguments at the call site.

Function arguments are checked to ensure they align with the expected parameters' types.

### Examples

<img width="1309" alt="Screenshot 2023-06-16 at 11 14 05 PM" src="https://github.com/crane-lang/crane/assets/1486634/0a5e51bc-dcf6-4d37-a95a-342a50d342fb">

<img width="1309" alt="Screenshot 2023-06-16 at 11 14 38 PM" src="https://github.com/crane-lang/crane/assets/1486634/9547ee9a-b3f4-406e-aa26-3bc85d0d82a5">
