### PR TITLE
Add return values and types to functions

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -70,6 +70,7 @@ pub enum TyStmtKind {
 #[derive(Debug, Clone)]
 pub struct TyFn {
     pub params: ThinVec<TyFnParam>,
+    pub return_ty: Arc<Type>,
     pub body: ThinVec<TyStmt>,
 }
 

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -54,6 +54,7 @@ pub enum StmtKind {
 #[derive(Debug, Clone)]
 pub struct Fn {
     pub params: ThinVec<FnParam>,
+    pub return_ty: Option<Ident>,
     pub body: ThinVec<Stmt>,
 }
 

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -406,8 +406,6 @@ impl NativeBackend {
                         builder.build_return(None);
                     }
 
-                    module.print_to_stderr();
-
                     Self::verify_fn(&fpm, &item.name.to_string(), &fn_value).unwrap();
                 }
             }

--- a/crates/crane/src/lexer/token.rs
+++ b/crates/crane/src/lexer/token.rs
@@ -31,6 +31,10 @@ pub enum TokenKind {
     #[token(":")]
     Colon,
 
+    /// `->`
+    #[token("->")]
+    RightArrow,
+
     /// An identifier.
     #[regex(r"[A-Za-z_][A-Za-z0-9_]*")]
     Ident,

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -84,6 +84,12 @@ where
 
         self.consume(TokenKind::CloseParen);
 
+        let return_ty = if self.consume(TokenKind::RightArrow) {
+            Some(self.parse_ident()?)
+        } else {
+            None
+        };
+
         self.consume(TokenKind::OpenBrace);
 
         let mut body = ThinVec::new();
@@ -94,6 +100,13 @@ where
 
         self.consume(TokenKind::CloseBrace);
 
-        Ok((ident, Fn { params, body }))
+        Ok((
+            ident,
+            Fn {
+                params,
+                return_ty,
+                body,
+            },
+        ))
     }
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -5,9 +5,25 @@ pub fn main() {
     greet("world")
     greet("trees")
     greet("everyone")
+    println("")
+
+    print("This value is always ")
+    println(int_to_string(always_3()))
+    println("")
+
     add_and_print(1, 1)
     add_and_print(2, 2)
     add_and_print(3, 3)
+    print("7 + 5 = ")
+    println(int_to_string(add_5(7)))
+}
+
+fn always_3() -> Uint64 {
+    3
+}
+
+fn add_5(value: Uint64) -> Uint64 {
+    int_add(value, 5)
 }
 
 fn greet(name: String) {


### PR DESCRIPTION
This PR adds return values and types to functions.

Functions can now return values. The last expression in the function body is what is returned.

Functions can now have an optional return type:

```rs
pub fn get_random_number() -> Uint64 {
    // Chosen by fair dice roll.
    // Guaranteed to be random.
    4
}
```

Omitting the return type means the function returns `()` (unit).