### PR TITLE
Run `cargo fmt --check` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - run: cargo fmt --check
       - run: cargo build --verbose
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::ast::{Ident, Span};
 

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use thin_vec::ThinVec;
 


### PR DESCRIPTION
This PR adds `cargo fmt --check` as a CI step to ensure that code being merged is formatted properly.

Also fixes up some existing issues.