### PR TITLE
Parse `struct` and `union` declarations

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -129,6 +129,10 @@ pub struct TyVariant {
     pub span: Span,
 }
 
+/// A `struct` declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyStructDecl(pub TyVariantData);
+
 /// A `union` declaration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyUnionDecl {
@@ -144,7 +148,7 @@ pub enum TyItemKind {
     Fn(Box<TyFn>),
 
     /// A struct declaration (`struct`).
-    Struct(TyVariantData),
+    Struct(TyStructDecl),
 
     /// A union declaration (`union`).
     Union(TyUnionDecl),

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -90,11 +90,64 @@ pub struct TyStmt {
     pub span: Span,
 }
 
+/// A field declaration in a `struct` or [`Variant`] of a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyFieldDecl {
+    pub name: Option<Ident>,
+    pub ty: Ident,
+    pub span: Span,
+}
+
+/// The data for a `struct` or [`Variant`] of a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TyVariantData {
+    /// A struct variant.
+    Struct(ThinVec<TyFieldDecl>),
+
+    /// A tuple variant.
+    Tuple(ThinVec<TyFieldDecl>),
+
+    /// A unit variant.
+    Unit,
+}
+
+impl TyVariantData {
+    /// Return the fields of this variant.
+    pub fn fields(&self) -> &[TyFieldDecl] {
+        match self {
+            TyVariantData::Struct(fields) | TyVariantData::Tuple(fields) => fields,
+            _ => &[],
+        }
+    }
+}
+
+/// A variant in a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyVariant {
+    pub name: Ident,
+    pub data: TyVariantData,
+    pub span: Span,
+}
+
+/// A `union` declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyUnionDecl {
+    /// The variants of the `union`.
+    pub variants: ThinVec<TyVariant>,
+}
+
 /// The kind of a [`TyItem`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyItemKind {
+    // TODO: Remove `Box`?
     /// A function declaration (`fn`).
     Fn(Box<TyFn>),
+
+    /// A struct declaration (`struct`).
+    Struct(TyVariantData),
+
+    /// A union declaration (`union`).
+    Union(TyUnionDecl),
 }
 
 /// An item in a [`TyModule`].

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -113,6 +113,10 @@ pub struct Variant {
     pub span: Span,
 }
 
+/// A `struct` declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructDecl(pub VariantData);
+
 /// A `union` declaration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnionDecl {
@@ -127,7 +131,7 @@ pub enum ItemKind {
     Fn(Box<Fn>),
 
     /// A struct declaration (`struct`).
-    Struct(VariantData),
+    Struct(StructDecl),
 
     /// A union declaration (`union`).
     Union(UnionDecl),

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -96,11 +96,11 @@ pub enum VariantData {
 }
 
 impl VariantData {
-    /// Return the fields of this variant.
+    /// Return the fields in this [`VariantData`].
     pub fn fields(&self) -> &[FieldDecl] {
         match self {
             VariantData::Struct(fields) | VariantData::Tuple(fields) => fields,
-            _ => &[],
+            VariantData::Unit => &[],
         }
     }
 }

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -74,11 +74,63 @@ pub struct Stmt {
     pub span: Span,
 }
 
+/// A field declaration in a `struct` or [`Variant`] of a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldDecl {
+    pub name: Option<Ident>,
+    pub ty: Ident,
+    pub span: Span,
+}
+
+/// The data for a `struct` or [`Variant`] of a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum VariantData {
+    /// A struct variant.
+    Struct(ThinVec<FieldDecl>),
+
+    /// A tuple variant.
+    Tuple(ThinVec<FieldDecl>),
+
+    /// A unit variant.
+    Unit,
+}
+
+impl VariantData {
+    /// Return the fields of this variant.
+    pub fn fields(&self) -> &[FieldDecl] {
+        match self {
+            VariantData::Struct(fields) | VariantData::Tuple(fields) => fields,
+            _ => &[],
+        }
+    }
+}
+
+/// A variant in a `union`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Variant {
+    pub name: Ident,
+    pub data: VariantData,
+    pub span: Span,
+}
+
+/// A `union` declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnionDecl {
+    /// The variants of the `union`.
+    pub variants: ThinVec<Variant>,
+}
+
 /// The kind of an [`Item`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ItemKind {
     /// A function declaration (`fn`).
     Fn(Box<Fn>),
+
+    /// A struct declaration (`struct`).
+    Struct(VariantData),
+
+    /// A union declaration (`union`).
+    Union(UnionDecl),
 }
 
 /// An item in a [`Module`].

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -408,6 +408,8 @@ impl NativeBackend {
 
                     Self::verify_fn(&fpm, &item.name.to_string(), &fn_value).unwrap();
                 }
+                TyItemKind::Struct(_) => {}
+                TyItemKind::Union(_) => {}
             }
         }
 

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -22,6 +22,20 @@ enum ExpectedToken {
     Ident,
 }
 
+impl std::fmt::Display for ExpectedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Token(kind) => format!("`{kind:?}`"),
+                Self::Keyword(keyword) => format!("`{keyword}`"),
+                Self::Ident => "an identifier".to_string(),
+            }
+        )
+    }
+}
+
 pub struct Parser<TokenStream: Iterator<Item = Result<Token, LexError>>> {
     /// The list of tokens.
     tokens: TokenStream,
@@ -67,7 +81,14 @@ where
 
         if !self.is_at_end() {
             return Err(ParseError {
-                kind: ParseErrorKind::Error("Expected end of file".into()),
+                kind: ParseErrorKind::Error(format!(
+                    "Unexpected token. Expected {}.",
+                    self.expected_tokens
+                        .into_iter()
+                        .map(|expected| expected.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )),
                 span: self.token.span,
             });
         }

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -81,14 +81,7 @@ where
 
         if !self.is_at_end() {
             return Err(ParseError {
-                kind: ParseErrorKind::Error(format!(
-                    "Unexpected token. Expected {}.",
-                    self.expected_tokens
-                        .into_iter()
-                        .map(|expected| expected.to_string())
-                        .collect::<Vec<_>>()
-                        .join(" ")
-                )),
+                kind: ParseErrorKind::Error("Failed to parse.".to_string()),
                 span: self.token.span,
             });
         }

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -1,7 +1,9 @@
 use thin_vec::ThinVec;
 use tracing::trace;
 
-use crate::ast::{FieldDecl, Fn, FnParam, Ident, Item, ItemKind, UnionDecl, Variant, VariantData};
+use crate::ast::{
+    FieldDecl, Fn, FnParam, Ident, Item, ItemKind, StructDecl, UnionDecl, Variant, VariantData,
+};
 use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
 use crate::parser::{ParseResult, Parser};
@@ -132,7 +134,7 @@ where
         ))
     }
 
-    fn parse_struct_decl(&mut self) -> ParseResult<(Ident, VariantData)> {
+    fn parse_struct_decl(&mut self) -> ParseResult<(Ident, StructDecl)> {
         trace!("parse_struct_decl");
 
         let ident = self.parse_ident()?;
@@ -167,7 +169,7 @@ where
 
         self.consume(TokenKind::CloseBrace);
 
-        Ok((ident, VariantData::Struct(fields)))
+        Ok((ident, StructDecl(VariantData::Struct(fields))))
     }
 
     fn parse_union_decl(&mut self) -> ParseResult<(Ident, UnionDecl)> {

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -203,11 +203,6 @@ where
 
         self.consume(TokenKind::CloseBrace);
 
-        Ok((
-            ident,
-            UnionDecl {
-                variants: ThinVec::new(),
-            },
-        ))
+        Ok((ident, UnionDecl { variants }))
     }
 }

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -22,6 +22,16 @@ mod keywords {
         name: SmolStr::new_inline("fn"),
         span: DUMMY_SPAN,
     };
+
+    pub const STRUCT: Ident = Ident {
+        name: SmolStr::new_inline("struct"),
+        span: DUMMY_SPAN,
+    };
+
+    pub const UNION: Ident = Ident {
+        name: SmolStr::new_inline("union"),
+        span: DUMMY_SPAN,
+    };
 }
 
 impl<TokenStream> Parser<TokenStream>

--- a/crates/crane/src/snapshot_inputs/struct_decls.crane
+++ b/crates/crane/src/snapshot_inputs/struct_decls.crane
@@ -1,0 +1,4 @@
+struct Point {
+    x: Uint64,
+    y: Uint64,
+}

--- a/crates/crane/src/snapshot_inputs/union_decls.crane
+++ b/crates/crane/src/snapshot_inputs/union_decls.crane
@@ -1,0 +1,4 @@
+union Bool {
+    True,
+    False,
+}

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@struct_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@struct_decls.crane.snap
@@ -1,0 +1,78 @@
+---
+source: crates/crane/src/lexer.rs
+expression: "lexer.into_iter().collect::<Vec<_>>()"
+input_file: crates/crane/src/snapshot_inputs/struct_decls.crane
+---
+- Ok:
+    kind: Ident
+    lexeme: struct
+    span:
+      start: 0
+      end: 6
+- Ok:
+    kind: Ident
+    lexeme: Point
+    span:
+      start: 7
+      end: 12
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 13
+      end: 14
+- Ok:
+    kind: Ident
+    lexeme: x
+    span:
+      start: 19
+      end: 20
+- Ok:
+    kind: Colon
+    lexeme: ":"
+    span:
+      start: 20
+      end: 21
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 22
+      end: 28
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 28
+      end: 29
+- Ok:
+    kind: Ident
+    lexeme: y
+    span:
+      start: 34
+      end: 35
+- Ok:
+    kind: Colon
+    lexeme: ":"
+    span:
+      start: 35
+      end: 36
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 37
+      end: 43
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 43
+      end: 44
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 45
+      end: 46
+

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@union_decls.crane.snap
@@ -1,0 +1,54 @@
+---
+source: crates/crane/src/lexer.rs
+expression: "lexer.into_iter().collect::<Vec<_>>()"
+input_file: crates/crane/src/snapshot_inputs/union_decls.crane
+---
+- Ok:
+    kind: Ident
+    lexeme: union
+    span:
+      start: 0
+      end: 5
+- Ok:
+    kind: Ident
+    lexeme: Bool
+    span:
+      start: 6
+      end: 10
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 11
+      end: 12
+- Ok:
+    kind: Ident
+    lexeme: "True"
+    span:
+      start: 17
+      end: 21
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 21
+      end: 22
+- Ok:
+    kind: Ident
+    lexeme: "False"
+    span:
+      start: 27
+      end: 32
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 32
+      end: 33
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 34
+      end: 35
+

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@struct_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@struct_decls.crane.snap
@@ -1,0 +1,41 @@
+---
+source: crates/crane/src/parser.rs
+expression: parser.parse()
+input_file: crates/crane/src/snapshot_inputs/struct_decls.crane
+---
+Ok:
+  - kind:
+      Struct:
+        Struct:
+          - name:
+              name: x
+              span:
+                start: 19
+                end: 20
+            ty:
+              name: Uint64
+              span:
+                start: 22
+                end: 28
+            span:
+              start: 19
+              end: 20
+          - name:
+              name: y
+              span:
+                start: 34
+                end: 35
+            ty:
+              name: Uint64
+              span:
+                start: 37
+                end: 43
+            span:
+              start: 34
+              end: 35
+    name:
+      name: Point
+      span:
+        start: 7
+        end: 12
+

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@union_decls.crane.snap
@@ -6,7 +6,25 @@ input_file: crates/crane/src/snapshot_inputs/union_decls.crane
 Ok:
   - kind:
       Union:
-        variants: []
+        variants:
+          - name:
+              name: "True"
+              span:
+                start: 17
+                end: 21
+            data: Unit
+            span:
+              start: 17
+              end: 21
+          - name:
+              name: "False"
+              span:
+                start: 27
+                end: 32
+            data: Unit
+            span:
+              start: 27
+              end: 32
     name:
       name: Bool
       span:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@union_decls.crane.snap
@@ -1,0 +1,15 @@
+---
+source: crates/crane/src/parser.rs
+expression: parser.parse()
+input_file: crates/crane/src/snapshot_inputs/union_decls.crane
+---
+Ok:
+  - kind:
+      Union:
+        variants: []
+    name:
+      name: Bool
+      span:
+        start: 6
+        end: 10
+

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@struct_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@struct_decls.crane.snap
@@ -1,0 +1,42 @@
+---
+source: crates/crane/src/typer.rs
+expression: typer.type_check_module(module)
+input_file: crates/crane/src/snapshot_inputs/struct_decls.crane
+---
+Ok:
+  items:
+    - kind:
+        Struct:
+          Struct:
+            - name:
+                name: x
+                span:
+                  start: 19
+                  end: 20
+              ty:
+                name: Uint64
+                span:
+                  start: 22
+                  end: 28
+              span:
+                start: 19
+                end: 20
+            - name:
+                name: y
+                span:
+                  start: 34
+                  end: 35
+              ty:
+                name: Uint64
+                span:
+                  start: 37
+                  end: 43
+              span:
+                start: 34
+                end: 35
+      name:
+        name: Point
+        span:
+          start: 7
+          end: 12
+

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
@@ -1,0 +1,16 @@
+---
+source: crates/crane/src/typer.rs
+expression: typer.type_check_module(module)
+input_file: crates/crane/src/snapshot_inputs/union_decls.crane
+---
+Ok:
+  items:
+    - kind:
+        Union:
+          variants: []
+      name:
+        name: Bool
+        span:
+          start: 6
+          end: 10
+

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
@@ -7,7 +7,25 @@ Ok:
   items:
     - kind:
         Union:
-          variants: []
+          variants:
+            - name:
+                name: "True"
+                span:
+                  start: 17
+                  end: 21
+              data: Unit
+              span:
+                start: 17
+                end: 21
+            - name:
+                name: "False"
+                span:
+                  start: 27
+                  end: 32
+              data: Unit
+              span:
+                start: 27
+                end: 32
       name:
         name: Bool
         span:

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -15,7 +15,8 @@ use crate::ast::visitor::{walk_expr, Visitor};
 use crate::ast::{
     Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Module, Span, Stmt,
     StmtKind, TyExpr, TyExprKind, TyFn, TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteral,
-    TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyUint, DUMMY_SPAN,
+    TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyUint, TyUnionDecl, TyVariantData, UnionDecl,
+    Variant, VariantData, DUMMY_SPAN,
 };
 
 fn ty_to_string(ty: &Type) -> String {
@@ -155,6 +156,8 @@ impl Typer {
 
                     self.register_function(item.name.clone(), params.clone(), return_ty);
                 }
+                ItemKind::Struct(_) => {}
+                ItemKind::Union(_) => {}
             }
         }
 
@@ -201,6 +204,14 @@ impl Typer {
         match item.kind {
             ItemKind::Fn(fun) => Ok(TyItem {
                 kind: TyItemKind::Fn(Box::new(self.infer_function(&item.name, *fun)?)),
+                name: item.name,
+            }),
+            ItemKind::Struct(struct_decl) => Ok(TyItem {
+                kind: TyItemKind::Struct(self.infer_struct_decl(&struct_decl)?),
+                name: item.name,
+            }),
+            ItemKind::Union(union_decl) => Ok(TyItem {
+                kind: TyItemKind::Union(self.infer_union_decl(&union_decl)?),
                 name: item.name,
             }),
         }
@@ -268,6 +279,14 @@ impl Typer {
                 span: param.span,
             })
             .collect::<ThinVec<_>>())
+    }
+
+    fn infer_struct_decl(&self, struct_decl: &VariantData) -> TypeCheckResult<TyVariantData> {
+        todo!()
+    }
+
+    fn infer_union_decl(&self, union_decl: &UnionDecl) -> TypeCheckResult<TyUnionDecl> {
+        todo!()
     }
 
     fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -14,9 +14,9 @@ use thin_vec::{thin_vec, ThinVec};
 use crate::ast::visitor::{walk_expr, Visitor};
 use crate::ast::{
     Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Module, Span, Stmt,
-    StmtKind, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral, TyItem,
-    TyItemKind, TyLiteral, TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyUint, TyUnionDecl,
-    TyVariant, TyVariantData, UnionDecl, VariantData, DUMMY_SPAN,
+    StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral,
+    TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyStructDecl,
+    TyUint, TyUnionDecl, TyVariant, TyVariantData, UnionDecl, VariantData, DUMMY_SPAN,
 };
 
 fn ty_to_string(ty: &Type) -> String {
@@ -281,38 +281,8 @@ impl Typer {
             .collect::<ThinVec<_>>())
     }
 
-    fn infer_struct_decl(&self, struct_decl: &VariantData) -> TypeCheckResult<TyVariantData> {
-        Ok(match &struct_decl {
-            VariantData::Struct(fields) => TyVariantData::Struct(
-                fields
-                    .into_iter()
-                    .map(|field| TyFieldDecl {
-                        name: field.name.clone(),
-                        ty: field.ty.clone(),
-                        span: field.span,
-                    })
-                    .collect::<ThinVec<_>>(),
-            ),
-            VariantData::Tuple(_) => todo!(),
-            VariantData::Unit => TyVariantData::Unit,
-        })
-    }
-
-    fn infer_variant_data(&self, variant_data: &VariantData) -> TypeCheckResult<TyVariantData> {
-        Ok(match &variant_data {
-            VariantData::Struct(fields) => TyVariantData::Struct(
-                fields
-                    .into_iter()
-                    .map(|field| TyFieldDecl {
-                        name: field.name.clone(),
-                        ty: field.ty.clone(),
-                        span: field.span,
-                    })
-                    .collect::<ThinVec<_>>(),
-            ),
-            VariantData::Tuple(_) => todo!(),
-            VariantData::Unit => TyVariantData::Unit,
-        })
+    fn infer_struct_decl(&self, struct_decl: &StructDecl) -> TypeCheckResult<TyStructDecl> {
+        Ok(TyStructDecl(self.infer_variant_data(&struct_decl.0)?))
     }
 
     fn infer_union_decl(&self, union_decl: &UnionDecl) -> TypeCheckResult<TyUnionDecl> {
@@ -330,6 +300,23 @@ impl Typer {
 
         Ok(TyUnionDecl {
             variants: ty_variants,
+        })
+    }
+
+    fn infer_variant_data(&self, variant_data: &VariantData) -> TypeCheckResult<TyVariantData> {
+        Ok(match &variant_data {
+            VariantData::Struct(fields) => TyVariantData::Struct(
+                fields
+                    .into_iter()
+                    .map(|field| TyFieldDecl {
+                        name: field.name.clone(),
+                        ty: field.ty.clone(),
+                        span: field.span,
+                    })
+                    .collect::<ThinVec<_>>(),
+            ),
+            VariantData::Tuple(_) => todo!(),
+            VariantData::Unit => TyVariantData::Unit,
         })
     }
 

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -1,6 +1,16 @@
 // TODO: Handle imports.
 // use std::io::{print, println}
 
+struct User {
+    name: String,
+    age: Uint64,
+}
+
+union Bool {
+    True,
+    False,
+}
+
 pub fn main() {
     greet("world")
     greet("trees")


### PR DESCRIPTION
This PR adds support for parsing `struct` and `union` declarations.

### Structs

```rs
struct User {
    name: String,
    age: Uint64,
}
```

### Unions

```rs
union Bool {
    True,
    False,
}
```

These are not yet supported in the type checker or the backend.