### PR TITLE
Add tests for AST node sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
       - run: cargo build --verbose
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}
-      - run: cargo test --verbose
+      - run: cargo test --verbose -- --no-capture
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
       - run: cargo build --verbose
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}
-      - run: cargo test --verbose -- --nocapture
+      - run: cargo test --verbose
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
       - run: cargo build --verbose
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}
-      - run: cargo test --verbose -- --no-capture
+      - run: cargo test --verbose -- --nocapture
         env:
           LLVM_SYS_160_PREFIX: ${{ env.LLVM_PATH }}

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -178,6 +178,14 @@ mod tests {
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
+        dbg!(size_of::<TyExpr>().to_string());
+        dbg!(size_of::<TyExprKind>().to_string());
+        dbg!(size_of::<TyFn>().to_string());
+        dbg!(size_of::<TyItem>().to_string());
+        dbg!(size_of::<TyItemKind>().to_string());
+        dbg!(size_of::<TyStmt>().to_string());
+        dbg!(size_of::<TyStmtKind>().to_string());
+
         insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
         insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -169,14 +169,15 @@ pub struct TyModule {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     fn test_ast_node_sizes() {
+        use std::mem::size_of;
+
         insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
         insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -175,6 +175,7 @@ mod tests {
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_ast_node_sizes() {
         insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
         insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -178,20 +178,12 @@ mod tests {
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
-        dbg!(size_of::<TyExpr>().to_string());
-        dbg!(size_of::<TyExprKind>().to_string());
-        dbg!(size_of::<TyFn>().to_string());
-        dbg!(size_of::<TyItem>().to_string());
-        dbg!(size_of::<TyItemKind>().to_string());
-        dbg!(size_of::<TyStmt>().to_string());
-        dbg!(size_of::<TyStmtKind>().to_string());
-
-        // insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
-        // insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
-        // insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
-        // insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
-        // insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
-        // insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
-        // insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"72");
+        insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
+        insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
+        insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
+        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
     }
 }

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -186,12 +186,12 @@ mod tests {
         dbg!(size_of::<TyStmt>().to_string());
         dbg!(size_of::<TyStmtKind>().to_string());
 
-        insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
-        insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
-        insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
-        insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
-        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
-        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
+        // insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
+        // insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
+        // insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
+        // insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
+        // insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
+        // insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
+        // insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
     }
 }

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -169,16 +169,25 @@ pub struct TyModule {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+    #[cfg(target_pointer_width = "64")]
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
-        insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"72");
+        #[cfg(target_arch = "x86_64")]
+        {
+            // For whatever reason, `TyExpr` is a slightly smaller size on x86_64.
+            insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"72");
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
+        }
+
         insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
         insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -166,3 +166,22 @@ pub struct TyItem {
 pub struct TyModule {
     pub items: ThinVec<TyItem>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::*;
+
+    /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
+    #[test]
+    fn test_ast_node_sizes() {
+        insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
+        insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
+        insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
+        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
+    }
+}

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -152,14 +152,15 @@ pub struct Module {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     fn test_ast_node_sizes() {
+        use std::mem::size_of;
+
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
         insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -161,20 +161,12 @@ mod tests {
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
-        dbg!(size_of::<Expr>()).to_string();
-        dbg!(size_of::<ExprKind>()).to_string();
-        dbg!(size_of::<Fn>()).to_string();
-        dbg!(size_of::<Item>()).to_string();
-        dbg!(size_of::<ItemKind>()).to_string();
-        dbg!(size_of::<Stmt>()).to_string();
-        dbg!(size_of::<StmtKind>()).to_string();
-
-        // insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
-        // insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
-        // insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
-        // insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
-        // insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
-        // insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
-        // insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
+        insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
+        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
     }
 }

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -169,12 +169,12 @@ mod tests {
         dbg!(size_of::<Stmt>()).to_string();
         dbg!(size_of::<StmtKind>()).to_string();
 
-        insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
-        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
-        insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
-        insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
+        // insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
+        // insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
+        // insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
+        // insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
+        // insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
+        // insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
+        // insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
     }
 }

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -158,6 +158,7 @@ mod tests {
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_ast_node_sizes() {
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -149,3 +149,22 @@ pub struct Item {
 pub struct Module {
     pub items: ThinVec<Item>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::*;
+
+    /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
+    #[test]
+    fn test_ast_node_sizes() {
+        insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
+        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
+    }
+}

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -152,12 +152,10 @@ pub struct Module {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of AST nodes to ensure they don't unintentionally get bigger.
     #[test]
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -161,6 +161,14 @@ mod tests {
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
+        dbg!(size_of::<Expr>()).to_string();
+        dbg!(size_of::<ExprKind>()).to_string();
+        dbg!(size_of::<Fn>()).to_string();
+        dbg!(size_of::<Item>()).to_string();
+        dbg!(size_of::<ItemKind>()).to_string();
+        dbg!(size_of::<Stmt>()).to_string();
+        dbg!(size_of::<StmtKind>()).to_string();
+
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
         insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -15,8 +15,22 @@ pub enum Type {
         name: SmolStr,
     },
 
+    /// A function type.
     Fn {
         args: ThinVec<Arc<Type>>,
         return_ty: Arc<Type>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::*;
+
+    /// Tests the size of [`Type`] to ensure it doesn't unintentionally get bigger.
+    #[test]
+    fn test_type_size() {
+        insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
+    }
 }

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -24,12 +24,10 @@ pub enum Type {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of [`Type`] to ensure it doesn't unintentionally get bigger.
     #[test]
-    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     fn test_type_size() {
         use std::mem::size_of;
 

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -30,6 +30,7 @@ mod tests {
 
     /// Tests the size of [`Type`] to ensure it doesn't unintentionally get bigger.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_type_size() {
         insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
     }

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -33,8 +33,6 @@ mod tests {
     fn test_type_size() {
         use std::mem::size_of;
 
-        dbg!(size_of::<Type>().to_string());
-
-        // insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
+        insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
     }
 }

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -35,6 +35,6 @@ mod tests {
 
         dbg!(size_of::<Type>().to_string());
 
-        insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
+        // insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
     }
 }

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -24,14 +24,15 @@ pub enum Type {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     use super::*;
 
     /// Tests the size of [`Type`] to ensure it doesn't unintentionally get bigger.
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
     fn test_type_size() {
+        use std::mem::size_of;
+
         insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
     }
 }

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -33,6 +33,8 @@ mod tests {
     fn test_type_size() {
         use std::mem::size_of;
 
+        dbg!(size_of::<Type>().to_string());
+
         insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
     }
 }


### PR DESCRIPTION
This PR adds tests for the sizes of various AST nodes to ensure that they don't unintentionally change.