### PR TITLE
Box `StmtKind` variants

### DIFF
--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -45,10 +45,10 @@ pub struct Expr {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StmtKind {
     /// An item.
-    Item(Item),
+    Item(Box<Item>),
 
     /// An expression.
-    Expr(Expr),
+    Expr(Box<Expr>),
 }
 
 /// A function definition.
@@ -164,7 +164,7 @@ mod tests {
         insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
-        insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"80");
-        insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"64");
+        insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"32");
+        insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"16");
     }
 }

--- a/crates/crane/src/parser/stmt.rs
+++ b/crates/crane/src/parser/stmt.rs
@@ -12,7 +12,7 @@ where
             let span = expr.span;
 
             return Ok(Some(Stmt {
-                kind: StmtKind::Expr(expr),
+                kind: StmtKind::Expr(Box::new(expr)),
                 span,
             }));
         }

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -323,7 +323,7 @@ impl Typer {
     fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
         Ok(TyStmt {
             kind: match stmt.kind {
-                StmtKind::Expr(expr) => TyStmtKind::Expr(self.infer_expr(expr)?),
+                StmtKind::Expr(expr) => TyStmtKind::Expr(self.infer_expr(*expr)?),
                 StmtKind::Item(_) => todo!(),
             },
             span: stmt.span,


### PR DESCRIPTION
This PR boxes `StmtKind` variants in order to reduce the size of the AST node.