### PR TITLE
Box `TyStmtKind` variants

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -61,10 +61,10 @@ pub struct TyExpr {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyStmtKind {
     /// An item.
-    Item(TyItem),
+    Item(Box<TyItem>),
 
     /// An expression.
-    Expr(TyExpr),
+    Expr(Box<TyExpr>),
 }
 
 /// A typed function definition.
@@ -192,7 +192,7 @@ mod tests {
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
         insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
-        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
-        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"32");
+        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"16");
     }
 }

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -391,7 +391,7 @@ impl NativeBackend {
                                     &module,
                                     &fun.params,
                                     &fn_value,
-                                    expr.clone(),
+                                    *expr.clone(),
                                 );
                             }
                             TyStmtKind::Item(_item) => todo!(),

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -323,7 +323,7 @@ impl Typer {
     fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
         Ok(TyStmt {
             kind: match stmt.kind {
-                StmtKind::Expr(expr) => TyStmtKind::Expr(self.infer_expr(*expr)?),
+                StmtKind::Expr(expr) => TyStmtKind::Expr(Box::new(self.infer_expr(*expr)?)),
                 StmtKind::Item(_) => todo!(),
             },
             span: stmt.span,


### PR DESCRIPTION
This PR boxes `TyStmtKind` variants in order to reduce the size of the AST nodes.

Missed this when I did #17.