### PR TITLE
Add `let` bindings

### DIFF
--- a/crates/crane/src/ast.rs
+++ b/crates/crane/src/ast.rs
@@ -4,6 +4,7 @@ mod span;
 mod typed;
 mod untyped;
 
+pub mod keywords;
 pub mod visitor;
 
 pub use ident::*;

--- a/crates/crane/src/ast/keywords.rs
+++ b/crates/crane/src/ast/keywords.rs
@@ -1,0 +1,28 @@
+use smol_str::SmolStr;
+
+use crate::ast::{Ident, DUMMY_SPAN};
+
+pub const PUB: Ident = Ident {
+    name: SmolStr::new_inline("pub"),
+    span: DUMMY_SPAN,
+};
+
+pub const FN: Ident = Ident {
+    name: SmolStr::new_inline("fn"),
+    span: DUMMY_SPAN,
+};
+
+pub const STRUCT: Ident = Ident {
+    name: SmolStr::new_inline("struct"),
+    span: DUMMY_SPAN,
+};
+
+pub const UNION: Ident = Ident {
+    name: SmolStr::new_inline("union"),
+    span: DUMMY_SPAN,
+};
+
+pub const LET: Ident = Ident {
+    name: SmolStr::new_inline("let"),
+    span: DUMMY_SPAN,
+};

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -61,13 +61,13 @@ pub struct TyExpr {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyStmtKind {
     /// A local `let` binding.
-    Local(TyLocal),
+    Local(Box<TyLocal>),
 
     /// An item.
-    Item(TyItem),
+    Item(Box<TyItem>),
 
     /// An expression.
-    Expr(TyExpr),
+    Expr(Box<TyExpr>),
 }
 
 /// The kind of a [`TyLocal`].
@@ -214,7 +214,7 @@ mod tests {
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
         insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
-        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"96");
-        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"80");
+        insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"32");
+        insta::assert_snapshot!(size_of::<TyStmtKind>().to_string(), @"16");
     }
 }

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -60,11 +60,33 @@ pub struct TyExpr {
 /// The kind of a [`TyStmt`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyStmtKind {
+    /// A local `let` binding.
+    Local(TyLocal),
+
     /// An item.
     Item(TyItem),
 
     /// An expression.
     Expr(TyExpr),
+}
+
+/// The kind of a [`TyLocal`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TyLocalKind {
+    /// A local declaration.
+    Decl,
+
+    /// A local declaration with an initializer.
+    Init(Box<TyExpr>),
+}
+
+/// A local `let` binding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyLocal {
+    pub kind: TyLocalKind,
+    pub name: Ident,
+    pub ty: Option<Arc<Type>>,
+    pub span: Span,
 }
 
 /// A typed function definition.

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -44,11 +44,43 @@ pub struct Expr {
 /// The kind of a [`Stmt`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StmtKind {
+    /// A local `let` binding.
+    Local(Box<Local>),
+
     /// An item.
     Item(Box<Item>),
 
     /// An expression.
     Expr(Box<Expr>),
+}
+
+/// The kind of a [`Local`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LocalKind {
+    /// A local declaration.
+    Decl,
+
+    /// A local declaration with an initializer.
+    Init(Box<Expr>),
+}
+
+impl LocalKind {
+    /// Returns the initializer for this local.
+    pub fn init(&self) -> Option<&Expr> {
+        match self {
+            Self::Decl => None,
+            Self::Init(init) => Some(init),
+        }
+    }
+}
+
+/// A local `let` binding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Local {
+    pub kind: LocalKind,
+    pub name: Ident,
+    pub ty: Option<Box<Ident>>,
+    pub span: Span,
 }
 
 /// A function definition.

--- a/crates/crane/src/ast/visitor.rs
+++ b/crates/crane/src/ast/visitor.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    Expr, ExprKind, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, Stmt, StmtKind, StructDecl,
-    UnionDecl, Variant, VariantData,
+    Expr, ExprKind, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, Local, Stmt, StmtKind,
+    StructDecl, UnionDecl, Variant, VariantData,
 };
 
 pub trait Visitor: Sized {
@@ -42,6 +42,10 @@ pub trait Visitor: Sized {
 
     fn visit_stmt(&mut self, stmt: &Stmt) {
         walk_stmt(self, stmt);
+    }
+
+    fn visit_local(&mut self, local: &Local) {
+        walk_local(self, local);
     }
 
     fn visit_expr(&mut self, expr: &Expr) {
@@ -111,8 +115,17 @@ pub fn walk_field_decl<V: Visitor>(visitor: &mut V, field: &FieldDecl) {
 
 pub fn walk_stmt<V: Visitor>(visitor: &mut V, stmt: &Stmt) {
     match &stmt.kind {
+        StmtKind::Local(local) => visitor.visit_local(local),
         StmtKind::Item(item) => visitor.visit_item(item),
         StmtKind::Expr(expr) => visitor.visit_expr(expr),
+    }
+}
+
+pub fn walk_local<V: Visitor>(visitor: &mut V, local: &Local) {
+    visitor.visit_ident(&local.name);
+
+    if let Some(ty) = &local.ty {
+        visitor.visit_ty(ty);
     }
 }
 

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -384,6 +384,7 @@ impl NativeBackend {
 
                     for stmt in &fun.body {
                         match &stmt.kind {
+                            TyStmtKind::Local(_) => {}
                             TyStmtKind::Expr(expr) => {
                                 last_stmt = Self::compile_expr(
                                     &self.context,

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -462,7 +462,7 @@ impl NativeBackend {
                                     &fun.params,
                                     &fn_value,
                                     &locals,
-                                    expr.clone(),
+                                    *expr.clone(),
                                 );
                             }
                             TyStmtKind::Item(_item) => todo!(),

--- a/crates/crane/src/lexer/token.rs
+++ b/crates/crane/src/lexer/token.rs
@@ -32,6 +32,10 @@ pub enum TokenKind {
     #[token(":")]
     Colon,
 
+    /// `=`
+    #[token("=")]
+    Equal,
+
     /// `->`
     #[token("->")]
     RightArrow,

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -34,6 +34,11 @@ mod keywords {
         name: SmolStr::new_inline("union"),
         span: DUMMY_SPAN,
     };
+
+    pub const LET: Ident = Ident {
+        name: SmolStr::new_inline("let"),
+        span: DUMMY_SPAN,
+    };
 }
 
 impl<TokenStream> Parser<TokenStream>

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -2,44 +2,14 @@ use thin_vec::ThinVec;
 use tracing::trace;
 
 use crate::ast::{
-    FieldDecl, Fn, FnParam, Ident, Item, ItemKind, StructDecl, UnionDecl, Variant, VariantData,
+    keywords, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, StructDecl, UnionDecl, Variant,
+    VariantData,
 };
 use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
 use crate::parser::{ParseResult, Parser};
 
 type ItemInfo = (Ident, ItemKind);
-
-mod keywords {
-    use smol_str::SmolStr;
-
-    use crate::ast::{Ident, DUMMY_SPAN};
-
-    pub const PUB: Ident = Ident {
-        name: SmolStr::new_inline("pub"),
-        span: DUMMY_SPAN,
-    };
-
-    pub const FN: Ident = Ident {
-        name: SmolStr::new_inline("fn"),
-        span: DUMMY_SPAN,
-    };
-
-    pub const STRUCT: Ident = Ident {
-        name: SmolStr::new_inline("struct"),
-        span: DUMMY_SPAN,
-    };
-
-    pub const UNION: Ident = Ident {
-        name: SmolStr::new_inline("union"),
-        span: DUMMY_SPAN,
-    };
-
-    pub const LET: Ident = Ident {
-        name: SmolStr::new_inline("let"),
-        span: DUMMY_SPAN,
-    };
-}
 
 impl<TokenStream> Parser<TokenStream>
 where

--- a/crates/crane/src/parser/stmt.rs
+++ b/crates/crane/src/parser/stmt.rs
@@ -1,13 +1,28 @@
-use crate::ast::{Stmt, StmtKind};
-use crate::lexer::token::Token;
+use tracing::trace;
+
+use crate::ast::{keywords, Local, LocalKind, Stmt, StmtKind};
+use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
-use crate::parser::{ParseResult, Parser};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, Parser};
 
 impl<TokenStream> Parser<TokenStream>
 where
     TokenStream: Iterator<Item = Result<Token, LexError>>,
 {
     pub fn parse_stmt(&mut self) -> ParseResult<Option<Stmt>> {
+        trace!("parse_stmt");
+
+        if self.consume_keyword(keywords::LET) {
+            let local = self.parse_local()?;
+
+            let span = local.span;
+
+            return Ok(Some(Stmt {
+                kind: StmtKind::Local(Box::new(local)),
+                span,
+            }));
+        }
+
         if let Some(expr) = self.parse_expr()? {
             let span = expr.span;
 
@@ -18,5 +33,30 @@ where
         }
 
         Ok(None)
+    }
+
+    fn parse_local(&mut self) -> ParseResult<Local> {
+        trace!("parse_local");
+
+        let name = self.parse_ident()?;
+
+        self.consume(TokenKind::Equal);
+
+        let init = self.parse_expr()?.ok_or_else(|| ParseError {
+            kind: ParseErrorKind::Error(format!(
+                "Expected an initializer for this `{}` binding.",
+                keywords::LET
+            )),
+            span: self.token.span,
+        })?;
+
+        let span = name.span;
+
+        Ok(Local {
+            kind: LocalKind::Init(Box::new(init)),
+            name,
+            span,
+            ty: None,
+        })
     }
 }

--- a/crates/crane/src/snapshot_inputs/let_bindings.crane
+++ b/crates/crane/src/snapshot_inputs/let_bindings.crane
@@ -1,0 +1,12 @@
+pub fn main() {
+    let name = "Arya"
+    let gold = 100
+
+    print("Hello, ")
+    print(name)
+    println(".")
+
+    print("You currently have ")
+    print(int_to_string(gold))
+    println(" gold at your disposal.")
+}

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
@@ -1,0 +1,258 @@
+---
+source: crates/crane/src/lexer.rs
+expression: "lexer.into_iter().collect::<Vec<_>>()"
+input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
+---
+- Ok:
+    kind: Ident
+    lexeme: pub
+    span:
+      start: 0
+      end: 3
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 4
+      end: 6
+- Ok:
+    kind: Ident
+    lexeme: main
+    span:
+      start: 7
+      end: 11
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 11
+      end: 12
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 12
+      end: 13
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 14
+      end: 15
+- Ok:
+    kind: Ident
+    lexeme: let
+    span:
+      start: 20
+      end: 23
+- Ok:
+    kind: Ident
+    lexeme: name
+    span:
+      start: 24
+      end: 28
+- Ok:
+    kind: Equal
+    lexeme: "="
+    span:
+      start: 29
+      end: 30
+- Ok:
+    kind: String
+    lexeme: "\"Arya\""
+    span:
+      start: 31
+      end: 37
+- Ok:
+    kind: Ident
+    lexeme: let
+    span:
+      start: 42
+      end: 45
+- Ok:
+    kind: Ident
+    lexeme: gold
+    span:
+      start: 46
+      end: 50
+- Ok:
+    kind: Equal
+    lexeme: "="
+    span:
+      start: 51
+      end: 52
+- Ok:
+    kind: Integer
+    lexeme: "100"
+    span:
+      start: 53
+      end: 56
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 62
+      end: 67
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 67
+      end: 68
+- Ok:
+    kind: String
+    lexeme: "\"Hello, \""
+    span:
+      start: 68
+      end: 77
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 77
+      end: 78
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 83
+      end: 88
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 88
+      end: 89
+- Ok:
+    kind: Ident
+    lexeme: name
+    span:
+      start: 89
+      end: 93
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 93
+      end: 94
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 99
+      end: 106
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 106
+      end: 107
+- Ok:
+    kind: String
+    lexeme: "\".\""
+    span:
+      start: 107
+      end: 110
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 110
+      end: 111
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 117
+      end: 122
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 122
+      end: 123
+- Ok:
+    kind: String
+    lexeme: "\"You currently have \""
+    span:
+      start: 123
+      end: 144
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 144
+      end: 145
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 150
+      end: 155
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 155
+      end: 156
+- Ok:
+    kind: Ident
+    lexeme: int_to_string
+    span:
+      start: 156
+      end: 169
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 169
+      end: 170
+- Ok:
+    kind: Ident
+    lexeme: gold
+    span:
+      start: 170
+      end: 174
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 174
+      end: 175
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 175
+      end: 176
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 181
+      end: 188
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 188
+      end: 189
+- Ok:
+    kind: String
+    lexeme: "\" gold at your disposal.\""
+    span:
+      start: 189
+      end: 214
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 214
+      end: 215
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 216
+      end: 217
+

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -1,0 +1,260 @@
+---
+source: crates/crane/src/parser.rs
+expression: parser.parse()
+input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
+---
+Ok:
+  - kind:
+      Fn:
+        params: []
+        return_ty: ~
+        body:
+          - kind:
+              Local:
+                kind:
+                  Init:
+                    kind:
+                      Literal:
+                        kind: String
+                        value: "\"Arya\""
+                    span:
+                      start: 31
+                      end: 37
+                name:
+                  name: name
+                  span:
+                    start: 24
+                    end: 28
+                ty: ~
+                span:
+                  start: 24
+                  end: 28
+            span:
+              start: 24
+              end: 28
+          - kind:
+              Local:
+                kind:
+                  Init:
+                    kind:
+                      Literal:
+                        kind: Integer
+                        value: "100"
+                    span:
+                      start: 53
+                      end: 56
+                name:
+                  name: gold
+                  span:
+                    start: 46
+                    end: 50
+                ty: ~
+                span:
+                  start: 46
+                  end: 50
+            span:
+              start: 46
+              end: 50
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: print
+                            span:
+                              start: 62
+                              end: 67
+                      span:
+                        start: 62
+                        end: 67
+                    args:
+                      - kind:
+                          Literal:
+                            kind: String
+                            value: "\"Hello, \""
+                        span:
+                          start: 68
+                          end: 77
+                span:
+                  start: 62
+                  end: 67
+            span:
+              start: 62
+              end: 67
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: print
+                            span:
+                              start: 83
+                              end: 88
+                      span:
+                        start: 83
+                        end: 88
+                    args:
+                      - kind:
+                          Variable:
+                            name:
+                              name: name
+                              span:
+                                start: 89
+                                end: 93
+                        span:
+                          start: 89
+                          end: 93
+                span:
+                  start: 83
+                  end: 88
+            span:
+              start: 83
+              end: 88
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: println
+                            span:
+                              start: 99
+                              end: 106
+                      span:
+                        start: 99
+                        end: 106
+                    args:
+                      - kind:
+                          Literal:
+                            kind: String
+                            value: "\".\""
+                        span:
+                          start: 107
+                          end: 110
+                span:
+                  start: 99
+                  end: 106
+            span:
+              start: 99
+              end: 106
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: print
+                            span:
+                              start: 117
+                              end: 122
+                      span:
+                        start: 117
+                        end: 122
+                    args:
+                      - kind:
+                          Literal:
+                            kind: String
+                            value: "\"You currently have \""
+                        span:
+                          start: 123
+                          end: 144
+                span:
+                  start: 117
+                  end: 122
+            span:
+              start: 117
+              end: 122
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: print
+                            span:
+                              start: 150
+                              end: 155
+                      span:
+                        start: 150
+                        end: 155
+                    args:
+                      - kind:
+                          Call:
+                            fun:
+                              kind:
+                                Variable:
+                                  name:
+                                    name: int_to_string
+                                    span:
+                                      start: 156
+                                      end: 169
+                              span:
+                                start: 156
+                                end: 169
+                            args:
+                              - kind:
+                                  Variable:
+                                    name:
+                                      name: gold
+                                      span:
+                                        start: 170
+                                        end: 174
+                                span:
+                                  start: 170
+                                  end: 174
+                        span:
+                          start: 156
+                          end: 169
+                span:
+                  start: 150
+                  end: 155
+            span:
+              start: 150
+              end: 155
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          name:
+                            name: println
+                            span:
+                              start: 181
+                              end: 188
+                      span:
+                        start: 181
+                        end: 188
+                    args:
+                      - kind:
+                          Literal:
+                            kind: String
+                            value: "\" gold at your disposal.\""
+                        span:
+                          start: 189
+                          end: 214
+                span:
+                  start: 181
+                  end: 188
+            span:
+              start: 181
+              end: 188
+    name:
+      name: main
+      span:
+        start: 7
+        end: 11
+

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
@@ -1,0 +1,379 @@
+---
+source: crates/crane/src/typer.rs
+expression: typer.type_check_module(module)
+input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
+---
+Ok:
+  items:
+    - kind:
+        Fn:
+          params: []
+          return_ty:
+            UserDefined:
+              module: "std::prelude"
+              name: ()
+          body:
+            - kind:
+                Local:
+                  kind:
+                    Init:
+                      kind:
+                        Literal:
+                          kind:
+                            String: "\"Arya\""
+                          span:
+                            start: 31
+                            end: 37
+                      span:
+                        start: 31
+                        end: 37
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: String
+                  name:
+                    name: name
+                    span:
+                      start: 24
+                      end: 28
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: String
+                  span:
+                    start: 24
+                    end: 28
+              span:
+                start: 24
+                end: 28
+            - kind:
+                Local:
+                  kind:
+                    Init:
+                      kind:
+                        Literal:
+                          kind:
+                            Integer:
+                              Unsigned:
+                                - 100
+                                - Uint64
+                          span:
+                            start: 53
+                            end: 56
+                      span:
+                        start: 53
+                        end: 56
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: Uint64
+                  name:
+                    name: gold
+                    span:
+                      start: 46
+                      end: 50
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: Uint64
+                  span:
+                    start: 46
+                    end: 50
+              span:
+                start: 46
+                end: 50
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: print
+                              span:
+                                start: 62
+                                end: 67
+                        span:
+                          start: 62
+                          end: 67
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Literal:
+                              kind:
+                                String: "\"Hello, \""
+                              span:
+                                start: 68
+                                end: 77
+                          span:
+                            start: 68
+                            end: 77
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 62
+                    end: 67
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 62
+                end: 67
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: print
+                              span:
+                                start: 83
+                                end: 88
+                        span:
+                          start: 83
+                          end: 88
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Variable:
+                              name:
+                                name: name
+                                span:
+                                  start: 89
+                                  end: 93
+                          span:
+                            start: 89
+                            end: 93
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 83
+                    end: 88
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 83
+                end: 88
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: println
+                              span:
+                                start: 99
+                                end: 106
+                        span:
+                          start: 99
+                          end: 106
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Literal:
+                              kind:
+                                String: "\".\""
+                              span:
+                                start: 107
+                                end: 110
+                          span:
+                            start: 107
+                            end: 110
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 99
+                    end: 106
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 99
+                end: 106
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: print
+                              span:
+                                start: 117
+                                end: 122
+                        span:
+                          start: 117
+                          end: 122
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Literal:
+                              kind:
+                                String: "\"You currently have \""
+                              span:
+                                start: 123
+                                end: 144
+                          span:
+                            start: 123
+                            end: 144
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 117
+                    end: 122
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 117
+                end: 122
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: print
+                              span:
+                                start: 150
+                                end: 155
+                        span:
+                          start: 150
+                          end: 155
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Call:
+                              fun:
+                                kind:
+                                  Variable:
+                                    name:
+                                      name: int_to_string
+                                      span:
+                                        start: 156
+                                        end: 169
+                                span:
+                                  start: 156
+                                  end: 169
+                                ty:
+                                  UserDefined:
+                                    module: "?"
+                                    name: "?"
+                              args:
+                                - kind:
+                                    Variable:
+                                      name:
+                                        name: gold
+                                        span:
+                                          start: 170
+                                          end: 174
+                                  span:
+                                    start: 170
+                                    end: 174
+                                  ty:
+                                    UserDefined:
+                                      module: "std::prelude"
+                                      name: Uint64
+                          span:
+                            start: 156
+                            end: 169
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 150
+                    end: 155
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 150
+                end: 155
+            - kind:
+                Expr:
+                  kind:
+                    Call:
+                      fun:
+                        kind:
+                          Variable:
+                            name:
+                              name: println
+                              span:
+                                start: 181
+                                end: 188
+                        span:
+                          start: 181
+                          end: 188
+                        ty:
+                          UserDefined:
+                            module: "?"
+                            name: "?"
+                      args:
+                        - kind:
+                            Literal:
+                              kind:
+                                String: "\" gold at your disposal.\""
+                              span:
+                                start: 189
+                                end: 214
+                          span:
+                            start: 189
+                            end: 214
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                  span:
+                    start: 181
+                    end: 188
+                  ty:
+                    UserDefined:
+                      module: "std::prelude"
+                      name: ()
+              span:
+                start: 181
+                end: 188
+      name:
+        name: main
+        span:
+          start: 7
+          end: 11
+

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -322,7 +322,7 @@ impl Typer {
         })
     }
 
-    fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
+    fn infer_stmt(&mut self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
         Ok(TyStmt {
             kind: match stmt.kind {
                 StmtKind::Local(local) => TyStmtKind::Local(self.infer_local(*local)?),
@@ -333,7 +333,7 @@ impl Typer {
         })
     }
 
-    fn infer_local(&self, local: Local) -> TypeCheckResult<TyLocal> {
+    fn infer_local(&mut self, local: Local) -> TypeCheckResult<TyLocal> {
         let ty = match local.kind.init() {
             Some(init) => self.infer_expr(init.clone())?.ty,
             None => Arc::new(Type::UserDefined {
@@ -341,6 +341,10 @@ impl Typer {
                 name: "?".into(),
             }),
         };
+
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(local.name.clone(), ty.clone());
+        }
 
         Ok(TyLocal {
             kind: match local.kind {

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -325,8 +325,8 @@ impl Typer {
     fn infer_stmt(&mut self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
         Ok(TyStmt {
             kind: match stmt.kind {
-                StmtKind::Local(local) => TyStmtKind::Local(self.infer_local(*local)?),
-                StmtKind::Expr(expr) => TyStmtKind::Expr(self.infer_expr(*expr)?),
+                StmtKind::Local(local) => TyStmtKind::Local(Box::new(self.infer_local(*local)?)),
+                StmtKind::Expr(expr) => TyStmtKind::Expr(Box::new(self.infer_expr(*expr)?)),
                 StmtKind::Item(_) => todo!(),
             },
             span: stmt.span,

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -13,10 +13,11 @@ use thin_vec::{thin_vec, ThinVec};
 
 use crate::ast::visitor::{walk_expr, Visitor};
 use crate::ast::{
-    Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Module, Span, Stmt,
-    StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral,
-    TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyModule, TyStmt, TyStmtKind, TyStructDecl,
-    TyUint, TyUnionDecl, TyVariant, TyVariantData, UnionDecl, VariantData, DUMMY_SPAN,
+    Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Local, LocalKind,
+    Module, Span, Stmt, StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam,
+    TyIntegerLiteral, TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyLocal, TyLocalKind, TyModule,
+    TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl, TyVariant, TyVariantData, UnionDecl,
+    VariantData, DUMMY_SPAN,
 };
 
 fn ty_to_string(ty: &Type) -> String {
@@ -237,6 +238,7 @@ impl Typer {
 
         if let Some(last_stmt) = body.last() {
             let ty = match &last_stmt.kind {
+                TyStmtKind::Local(_) => todo!(),
                 TyStmtKind::Expr(expr) => &expr.ty,
                 TyStmtKind::Item(_) => todo!(),
             };
@@ -323,10 +325,31 @@ impl Typer {
     fn infer_stmt(&self, stmt: Stmt) -> TypeCheckResult<TyStmt> {
         Ok(TyStmt {
             kind: match stmt.kind {
+                StmtKind::Local(local) => TyStmtKind::Local(self.infer_local(*local)?),
                 StmtKind::Expr(expr) => TyStmtKind::Expr(self.infer_expr(*expr)?),
                 StmtKind::Item(_) => todo!(),
             },
             span: stmt.span,
+        })
+    }
+
+    fn infer_local(&self, local: Local) -> TypeCheckResult<TyLocal> {
+        let ty = match local.kind.init() {
+            Some(init) => self.infer_expr(init.clone())?.ty,
+            None => Arc::new(Type::UserDefined {
+                module: "?".into(),
+                name: "?".into(),
+            }),
+        };
+
+        Ok(TyLocal {
+            kind: match local.kind {
+                LocalKind::Decl => TyLocalKind::Decl,
+                LocalKind::Init(init) => TyLocalKind::Init(Box::new(self.infer_expr(*init)?)),
+            },
+            name: local.name,
+            ty: Some(ty),
+            span: local.span,
         })
     }
 

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -12,6 +12,11 @@ union Bool {
 }
 
 pub fn main() {
+    let greeting = "Hey"
+
+    print("greeting = ")
+    println(greeting)
+
     greet("world")
     greet("trees")
     greet("everyone")

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -12,14 +12,17 @@ union Bool {
 }
 
 pub fn main() {
-    // let twenty_three = 23
+    let twenty_three = 23
 
-    // println(int_to_string(twenty_three))
+    print("twenty_three = ")
+    println(int_to_string(twenty_three))
+    println(" ")
 
     let greeting = "Hey"
 
     print("greeting = ")
     println(greeting)
+    println(" ")
 
     greet("world")
     greet("trees")

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -12,6 +12,10 @@ union Bool {
 }
 
 pub fn main() {
+    // let twenty_three = 23
+
+    // println(int_to_string(twenty_three))
+
     let greeting = "Hey"
 
     print("greeting = ")


### PR DESCRIPTION
This PR adds the initial support for `let` bindings.

Currently `let` bindings must have an initializer and only support literal types in the initializer:

```rs
fn main() {
    let a_string = "Hey there!"
    let an_int = 777
}
```

`let` bindings can be used as arguments to functions:

```rs
fn main() {
    let greeting = "Hello, world!"

    println(greeting)
}
```