### PR TITLE
Allow function calls in `let` initializers

### DIFF
--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -419,29 +419,15 @@ impl NativeBackend {
 
                                 let value = match &local.kind {
                                     TyLocalKind::Decl => None,
-                                    TyLocalKind::Init(init) => match &init.kind {
-                                        TyExprKind::Literal(literal) => match &literal.kind {
-                                            TyLiteralKind::String(literal) => Some(
-                                                Self::compile_string_literal(
-                                                    &self.context,
-                                                    &builder,
-                                                    &module,
-                                                    literal.clone(),
-                                                )
-                                                .as_basic_value_enum(),
-                                            ),
-                                            TyLiteralKind::Integer(literal) => Some(
-                                                Self::compile_integer_literal(
-                                                    &self.context,
-                                                    &builder,
-                                                    &module,
-                                                    literal.clone(),
-                                                )
-                                                .as_basic_value_enum(),
-                                            ),
-                                        },
-                                        _ => todo!(),
-                                    },
+                                    TyLocalKind::Init(init) => Self::compile_expr(
+                                        &self.context,
+                                        &builder,
+                                        &module,
+                                        &fun.params,
+                                        &fn_value,
+                                        &locals,
+                                        *init.clone(),
+                                    ),
                                 }
                                 .unwrap_or_else(|| {
                                     panic!(

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -33,6 +33,16 @@ pub fn main() {
     println(int_to_string(always_3()))
     println("")
 
+    let also_always_3 = always_3()
+    print("This value is also always ")
+    println(int_to_string(also_always_3))
+    println("")
+
+    let ten = int_add(also_always_3, 7)
+    print("This value should be 10: ")
+    println(int_to_string(ten))
+    println("")
+
     add_and_print(1, 1)
     add_and_print(2, 2)
     add_and_print(3, 3)


### PR DESCRIPTION
This PR makes it so function calls can be used to initialize a `let` binding:

```rs
fn main() {
    let value = rand()

    print("The 100% random value is ")
    println(int_to_string(value))
}

fn rand() -> Uint64 {
    // Guaranteed to be random.
    4
}
```