### PR TITLE
Change instrumentation to `#[instrument]`

### DIFF
--- a/crates/crane/src/parser/expr.rs
+++ b/crates/crane/src/parser/expr.rs
@@ -10,9 +10,8 @@ impl<TokenStream> Parser<TokenStream>
 where
     TokenStream: Iterator<Item = Result<Token, LexError>>,
 {
+    #[tracing::instrument(skip(self))]
     pub fn parse_expr(&mut self) -> ParseResult<Option<Expr>> {
-        trace!("parse_expr");
-
         if self.check(TokenKind::String) {
             let string_literal = Expr {
                 kind: ExprKind::Literal(Literal {
@@ -74,9 +73,8 @@ where
         Ok(None)
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_call_expr(&mut self) -> ParseResult<ThinVec<Expr>> {
-        trace!("parse_call_expr");
-
         self.consume(TokenKind::OpenParen);
 
         let mut args = ThinVec::new();

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -16,9 +16,8 @@ where
     TokenStream: Iterator<Item = Result<Token, LexError>>,
 {
     /// Parses an [`Item`].
+    #[tracing::instrument(skip(self))]
     pub fn parse_item(&mut self) -> ParseResult<Option<Item>> {
-        trace!("parse_item");
-
         self.consume_keyword(keywords::PUB);
 
         Ok(self
@@ -26,9 +25,8 @@ where
             .map(|(name, kind)| Item { name, kind }))
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_item_kind(&mut self) -> ParseResult<Option<ItemInfo>> {
-        trace!("parse_item_kind");
-
         if self.consume_keyword(keywords::FN) {
             let (name, fun) = self.parse_fn()?;
 
@@ -50,9 +48,8 @@ where
         Ok(None)
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_fn(&mut self) -> ParseResult<(Ident, Fn)> {
-        trace!("parse_fn");
-
         let ident = self.parse_ident()?;
 
         self.consume(TokenKind::OpenParen);
@@ -109,9 +106,8 @@ where
         ))
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_struct_decl(&mut self) -> ParseResult<(Ident, StructDecl)> {
-        trace!("parse_struct_decl");
-
         let ident = self.parse_ident()?;
 
         self.consume(TokenKind::OpenBrace);
@@ -147,9 +143,8 @@ where
         Ok((ident, StructDecl(VariantData::Struct(fields))))
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_union_decl(&mut self) -> ParseResult<(Ident, UnionDecl)> {
-        trace!("parse_union_decl");
-
         let ident = self.parse_ident()?;
 
         self.consume(TokenKind::OpenBrace);

--- a/crates/crane/src/parser/stmt.rs
+++ b/crates/crane/src/parser/stmt.rs
@@ -9,9 +9,8 @@ impl<TokenStream> Parser<TokenStream>
 where
     TokenStream: Iterator<Item = Result<Token, LexError>>,
 {
+    #[tracing::instrument(skip(self))]
     pub fn parse_stmt(&mut self) -> ParseResult<Option<Stmt>> {
-        trace!("parse_stmt");
-
         if self.consume_keyword(keywords::LET) {
             let local = self.parse_local()?;
 
@@ -35,9 +34,8 @@ where
         Ok(None)
     }
 
+    #[tracing::instrument(skip(self))]
     fn parse_local(&mut self) -> ParseResult<Local> {
-        trace!("parse_local");
-
         let name = self.parse_ident()?;
 
         self.consume(TokenKind::Equal);


### PR DESCRIPTION
This PR updates the instrumentation in the parser to use `#[instrument]` instead of manual traces.