### PR TITLE
Add `--example` flag to `crane build` and `crane run`

### DIFF
--- a/crates/crane/src/ast/source_span.rs
+++ b/crates/crane/src/ast/source_span.rs
@@ -6,6 +6,15 @@ pub struct SourceSpan {
     pub span: Span,
 }
 
+impl From<(&String, Span)> for SourceSpan {
+    fn from(value: (&String, Span)) -> Self {
+        Self {
+            source: value.0.to_owned(),
+            span: value.1,
+        }
+    }
+}
+
 impl From<(&str, Span)> for SourceSpan {
     fn from(value: (&str, Span)) -> Self {
         Self {

--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -36,10 +36,18 @@ enum Command {
     },
 
     /// Compiles the current project.
-    Build,
+    Build {
+        /// Builds the given example.
+        #[arg(long)]
+        example: Option<String>,
+    },
 
     /// Runs the current project.
-    Run,
+    Run {
+        /// Runs the given example.
+        #[arg(long)]
+        example: Option<String>,
+    },
 }
 
 fn main() {
@@ -77,19 +85,27 @@ fn main() {
 
             main.write_all(hello_world_program.as_bytes()).unwrap();
         }
-        Command::Build => {
-            let _ = compile();
+        Command::Build { example } => {
+            let _ = compile(example);
         }
-        Command::Run => {
-            if compile().is_ok() {
+        Command::Run { example } => {
+            if compile(example).is_ok() {
                 run();
             }
         }
     }
 }
 
-fn compile() -> Result<(), ()> {
-    let source = std::fs::read_to_string("examples/scratch.crane").unwrap();
+fn compile(example: Option<String>) -> Result<(), ()> {
+    // TODO: Don't force the usage of an example.
+    let example = example.unwrap_or("scratch".to_string());
+
+    let examples_path = PathBuf::from("examples");
+
+    let mut example_file = examples_path;
+    example_file.push(format!("{example}.crane"));
+
+    let source = std::fs::read_to_string(&example_file).unwrap();
 
     let lexer = Lexer::new(&source);
 
@@ -116,22 +132,24 @@ fn compile() -> Result<(), ()> {
                 Err(type_error) => {
                     let span = type_error.span;
 
+                    let example_file = example_file.display().to_string();
+
                     let error_report = match type_error.kind {
                         TypeErrorKind::UnknownFunction { name } => {
-                            Report::build(ReportKind::Error, "scratch.crane", 1)
+                            Report::build(ReportKind::Error, &example_file, 1)
                                 .with_message("A type error occurred.")
                                 .with_label(
-                                    Label::new(SourceSpan::from(("scratch.crane", span)))
+                                    Label::new(SourceSpan::from((&example_file, span)))
                                         .with_message(format!("Function `{name}` does not exist."))
                                         .with_color(Color::Red),
                                 )
                                 .finish()
                         }
                         TypeErrorKind::Error(message) => {
-                            Report::build(ReportKind::Error, "scratch.crane", 1)
+                            Report::build(ReportKind::Error, &example_file, 1)
                                 .with_message("A type error occurred.")
                                 .with_label(
-                                    Label::new(SourceSpan::from(("scratch.crane", span)))
+                                    Label::new(SourceSpan::from((&example_file, span)))
                                         .with_message(message)
                                         .with_color(Color::Red),
                                 )
@@ -140,7 +158,7 @@ fn compile() -> Result<(), ()> {
                     };
 
                     error_report
-                        .eprint(("scratch.crane".into(), Source::from(source)))
+                        .eprint((example_file.into(), Source::from(source)))
                         .unwrap();
 
                     Err(())
@@ -150,22 +168,24 @@ fn compile() -> Result<(), ()> {
         Err(err) => {
             let span = err.span;
 
+            let example_file = example_file.display().to_string();
+
             let error_report = match err.kind {
                 ParseErrorKind::LexError(lex_error) => {
-                    Report::build(ReportKind::Error, "scratch.crane", 1)
+                    Report::build(ReportKind::Error, &example_file, 1)
                         .with_message("An error occurred during lexing.")
                         .with_label(
-                            Label::new(SourceSpan::from(("scratch.crane", span)))
+                            Label::new(SourceSpan::from((&example_file, span)))
                                 .with_message(lex_error)
                                 .with_color(Color::Red),
                         )
                         .finish()
                 }
                 ParseErrorKind::Error(message) => {
-                    Report::build(ReportKind::Error, "scratch.crane", 1)
+                    Report::build(ReportKind::Error, &example_file, 1)
                         .with_message("An error occurred during parsing.")
                         .with_label(
-                            Label::new(SourceSpan::from(("scratch.crane", span)))
+                            Label::new(SourceSpan::from((&example_file, span)))
                                 .with_message(message)
                                 .with_color(Color::Red),
                         )
@@ -174,7 +194,7 @@ fn compile() -> Result<(), ()> {
             };
 
             error_report
-                .eprint(("scratch.crane".into(), Source::from(source)))
+                .eprint((example_file.into(), Source::from(source)))
                 .unwrap();
 
             Err(())


### PR DESCRIPTION
This PR adds an `--example` flag to `crane build` and `crane run` to allow specifying which program in the `examples/` directory should be built or run.

This helps remove some of the hard-coding of `scratch.crane` everywhere (although that is still the default program that gets run if `--example` is not provided.

```
$ crane build --help
Compiles the current project

Usage: crane build [OPTIONS]

Options:
      --example <EXAMPLE>  Builds the given example
  -h, --help               Print help
```

```
$ crane run --help
Runs the current project

Usage: crane run [OPTIONS]

Options:
      --example <EXAMPLE>  Runs the given example
  -h, --help               Print help
```