### PR TITLE
Add `Package` as top-level AST node

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -189,6 +189,12 @@ pub struct TyModule {
     pub items: ThinVec<TyItem>,
 }
 
+/// A package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyPackage {
+    pub modules: ThinVec<TyModule>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -182,6 +182,12 @@ pub struct Module {
     pub items: ThinVec<Item>,
 }
 
+/// A package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Package {
+    pub modules: ThinVec<Module>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -18,8 +18,8 @@ use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
 use crate::ast::{
-    Ident, TyExpr, TyExprKind, TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteralKind,
-    TyLocalKind, TyStmtKind, TyUint,
+    Ident, TyExpr, TyExprKind, TyFnParam, TyIntegerLiteral, TyItemKind, TyLiteralKind, TyLocalKind,
+    TyPackage, TyStmtKind, TyUint,
 };
 use crate::typer::Type;
 
@@ -34,7 +34,7 @@ impl NativeBackend {
         }
     }
 
-    pub fn compile(&self, program: Vec<TyItem>) {
+    pub fn compile(&self, package: TyPackage) {
         Target::initialize_aarch64(&InitializationConfig::default());
 
         let opt = OptimizationLevel::Default;
@@ -299,10 +299,12 @@ impl NativeBackend {
             Self::verify_fn(&fpm, fn_name, &fn_value).unwrap();
         }
 
-        for item in program
+        for item in package
+            .modules
+            .into_iter()
+            .flat_map(|module| module.items)
             // HACK: Reverse the items so we define the helper functions before `main`.
             // This should be replaced with a call graph.
-            .into_iter()
             .rev()
         {
             match item.kind {

--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -11,11 +11,12 @@ use ariadne::{Color, Label, Report, ReportKind, Source};
 use ast::SourceSpan;
 use clap::{Parser, Subcommand};
 use lexer::Lexer;
+use thin_vec::thin_vec;
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 use typer::TypeErrorKind;
 
-use crate::ast::Module;
+use crate::ast::{Module, Package};
 use crate::backend::native::NativeBackend;
 use crate::parser::ParseErrorKind;
 use crate::typer::Typer;
@@ -117,13 +118,17 @@ fn compile(example: Option<String>) -> Result<(), ()> {
 
             let module = Module { items };
 
-            match typer.type_check_module(module) {
-                Ok(typed_module) => {
+            let package = Package {
+                modules: thin_vec![module],
+            };
+
+            match typer.type_check_package(package) {
+                Ok(typed_package) => {
                     std::fs::create_dir_all("build").unwrap();
 
                     let backend = NativeBackend::new();
 
-                    backend.compile(typed_module.items.into());
+                    backend.compile(typed_package);
 
                     println!("Compiled!");
 

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -14,10 +14,10 @@ use thin_vec::{thin_vec, ThinVec};
 use crate::ast::visitor::{walk_expr, Visitor};
 use crate::ast::{
     Expr, ExprKind, Fn, FnParam, Ident, Item, ItemKind, Literal, LiteralKind, Local, LocalKind,
-    Module, Span, Stmt, StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam,
-    TyIntegerLiteral, TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyLocal, TyLocalKind, TyModule,
-    TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl, TyVariant, TyVariantData, UnionDecl,
-    VariantData, DUMMY_SPAN,
+    Module, Package, Span, Stmt, StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn,
+    TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyLocal,
+    TyLocalKind, TyModule, TyPackage, TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl,
+    TyVariant, TyVariantData, UnionDecl, VariantData, DUMMY_SPAN,
 };
 
 fn ty_to_string(ty: &Type) -> String {
@@ -49,6 +49,18 @@ impl Typer {
             module_functions: HashMap::new(),
             scopes: Vec::new(),
         }
+    }
+
+    pub fn type_check_package(&mut self, package: Package) -> TypeCheckResult<TyPackage> {
+        let mut typed_modules = ThinVec::new();
+
+        for module in package.modules {
+            typed_modules.push(self.type_check_module(module)?);
+        }
+
+        Ok(TyPackage {
+            modules: typed_modules,
+        })
     }
 
     pub fn type_check_module(&mut self, module: Module) -> TypeCheckResult<TyModule> {


### PR DESCRIPTION
This PR introduces `Package` as a top-level AST node.

A `Package` may contain many `Module`s, which in turn may contain many `Item`s.