### PR TITLE
Parse `use` items

### DIFF
--- a/crates/crane/src/ast/keywords.rs
+++ b/crates/crane/src/ast/keywords.rs
@@ -26,3 +26,8 @@ pub const UNION: Ident = Ident {
     name: SmolStr::new_inline("union"),
     span: DUMMY_SPAN,
 };
+
+pub const USE: Ident = Ident {
+    name: SmolStr::new_inline("use"),
+    span: DUMMY_SPAN,
+};

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -165,6 +165,9 @@ pub struct TyUnionDecl {
 /// The kind of a [`TyItem`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyItemKind {
+    /// A use declaration (`use`).
+    Use,
+
     // TODO: Remove `Box`?
     /// A function declaration (`fn`).
     Fn(Box<TyFn>),

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -4,6 +4,21 @@ use thin_vec::ThinVec;
 
 use crate::ast::{Ident, Span};
 
+/// A path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Path {
+    /// The segments in the path.
+    pub segments: ThinVec<PathSegment>,
+    pub span: Span,
+}
+
+/// A segment of a [`Path`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathSegment {
+    /// The identifier portion of this segment.
+    pub ident: Ident,
+}
+
 /// The kind of an [`Expr`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExprKind {
@@ -83,6 +98,19 @@ pub struct Local {
     pub span: Span,
 }
 
+/// The kind of a [`UseTree`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UseTreeKind {
+    Single,
+}
+
+/// A tree of paths with a common prefix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UseTree {
+    pub prefix: Path,
+    pub kind: UseTreeKind,
+}
+
 /// A function definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fn {
@@ -159,6 +187,9 @@ pub struct UnionDecl {
 /// The kind of an [`Item`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ItemKind {
+    /// A use declaration (`use`).
+    Use(UseTree),
+
     /// A function declaration (`fn`).
     Fn(Box<Fn>),
 
@@ -200,8 +231,8 @@ mod tests {
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
         insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<Item>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<Item>().to_string(), @"72");
+        insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"16");
     }

--- a/crates/crane/src/ast/visitor.rs
+++ b/crates/crane/src/ast/visitor.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    Expr, ExprKind, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, Local, Stmt, StmtKind,
-    StructDecl, UnionDecl, Variant, VariantData,
+    Expr, ExprKind, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, Local, Path, PathSegment, Stmt,
+    StmtKind, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant, VariantData,
 };
 
 pub trait Visitor: Sized {
@@ -10,6 +10,18 @@ pub trait Visitor: Sized {
 
     fn visit_item(&mut self, item: &Item) {
         walk_item(self, item);
+    }
+
+    fn visit_use_tree(&mut self, use_tree: &UseTree) {
+        walk_use_tree(self, use_tree);
+    }
+
+    fn visit_path(&mut self, path: &Path) {
+        walk_path(self, path);
+    }
+
+    fn visit_path_segment(&mut self, path_segment: &PathSegment) {
+        walk_path_segment(self, path_segment);
     }
 
     fn visit_fn(&mut self, fun: &Fn) {
@@ -57,6 +69,9 @@ pub fn walk_item<V: Visitor>(visitor: &mut V, item: &Item) {
     visitor.visit_ident(&item.name);
 
     match &item.kind {
+        ItemKind::Use(use_tree) => {
+            visitor.visit_use_tree(use_tree);
+        }
         ItemKind::Fn(fun) => {
             visitor.visit_fn(fun);
         }
@@ -67,6 +82,24 @@ pub fn walk_item<V: Visitor>(visitor: &mut V, item: &Item) {
             visitor.visit_union_decl(union_decl);
         }
     }
+}
+
+pub fn walk_use_tree<V: Visitor>(visitor: &mut V, use_tree: &UseTree) {
+    visitor.visit_path(&use_tree.prefix);
+
+    match &use_tree.kind {
+        UseTreeKind::Single => {}
+    }
+}
+
+pub fn walk_path<V: Visitor>(visitor: &mut V, path: &Path) {
+    for segment in &path.segments {
+        visitor.visit_path_segment(segment);
+    }
+}
+
+pub fn walk_path_segment<V: Visitor>(visitor: &mut V, path_segment: &PathSegment) {
+    visitor.visit_ident(&path_segment.ident);
 }
 
 pub fn walk_fn<V: Visitor>(visitor: &mut V, fun: &Fn) {

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -308,6 +308,7 @@ impl NativeBackend {
             .rev()
         {
             match item.kind {
+                TyItemKind::Use => {}
                 TyItemKind::Fn(fun) => {
                     let params = fun
                         .params

--- a/crates/crane/src/lexer/token.rs
+++ b/crates/crane/src/lexer/token.rs
@@ -32,6 +32,10 @@ pub enum TokenKind {
     #[token(":")]
     Colon,
 
+    /// `::`
+    #[token("::")]
+    ColonColon,
+
     /// `=`
     #[token("=")]
     Equal,

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -153,6 +153,7 @@ impl Typer {
 
         for item in &module.items {
             match item.kind {
+                ItemKind::Use(_) => {}
                 ItemKind::Fn(ref fun) => {
                     let params = self.infer_function_params(&fun.params)?;
 
@@ -215,6 +216,7 @@ impl Typer {
 
     fn infer_item(&mut self, item: Item) -> TypeCheckResult<TyItem> {
         match item.kind {
+            ItemKind::Use(_) => todo!(),
             ItemKind::Fn(fun) => Ok(TyItem {
                 kind: TyItemKind::Fn(Box::new(self.infer_function(&item.name, *fun)?)),
                 name: item.name,

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -216,7 +216,10 @@ impl Typer {
 
     fn infer_item(&mut self, item: Item) -> TypeCheckResult<TyItem> {
         match item.kind {
-            ItemKind::Use(_) => todo!(),
+            ItemKind::Use(_) => Ok(TyItem {
+                kind: TyItemKind::Use,
+                name: item.name,
+            }),
             ItemKind::Fn(fun) => Ok(TyItem {
                 kind: TyItemKind::Fn(Box::new(self.infer_function(&item.name, *fun)?)),
                 name: item.name,

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -1,5 +1,5 @@
-// TODO: Handle imports.
-// use std::io::{print, println}
+use std::io::print
+use std::io::println
 
 struct User {
     name: String,


### PR DESCRIPTION
This PR adds support to the parser for parsing `use` items, e.g., `use std::io::println`.