### PR TITLE
Use `Path`s to refer to `Variable`s in the AST

### DIFF
--- a/crates/crane/src/ast/span.rs
+++ b/crates/crane/src/ast/span.rs
@@ -19,6 +19,14 @@ impl Span {
     pub fn new(start: usize, end: usize) -> Self {
         Self { start, end }
     }
+
+    /// Returns a new [`Span`] that encloses `self and `end`.
+    pub fn to(self, end: Span) -> Self {
+        Self::new(
+            std::cmp::min(self.start, end.start),
+            std::cmp::max(self.end, end.end),
+        )
+    }
 }
 
 impl std::fmt::Debug for Span {
@@ -61,5 +69,26 @@ impl ariadne::Span for Span {
 
     fn end(&self) -> usize {
         self.end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_to_works_forwards() {
+        let start = Span::new(0, 3);
+        let end = Span::new(4, 6);
+
+        assert_eq!(start.to(end), Span::new(0, 6))
+    }
+
+    #[test]
+    fn span_to_works_backwards() {
+        let start = Span::new(3, 7);
+        let end = Span::new(0, 2);
+
+        assert_eq!(start.to(end), Span::new(0, 7))
     }
 }

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -228,8 +228,8 @@ mod tests {
     fn test_ast_node_sizes() {
         use std::mem::size_of;
 
-        insta::assert_snapshot!(size_of::<Expr>().to_string(), @"56");
-        insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"40");
+        insta::assert_snapshot!(size_of::<Expr>().to_string(), @"48");
+        insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<Item>().to_string(), @"72");
         insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"32");

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -26,7 +26,7 @@ pub enum ExprKind {
     Literal(Literal),
 
     /// A reference to a variable.
-    Variable { name: Ident },
+    Variable(Path),
 
     /// A function call.
     Call {

--- a/crates/crane/src/ast/visitor.rs
+++ b/crates/crane/src/ast/visitor.rs
@@ -165,7 +165,7 @@ pub fn walk_local<V: Visitor>(visitor: &mut V, local: &Local) {
 pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr) {
     match &expr.kind {
         ExprKind::Literal(_) => {}
-        ExprKind::Variable { name } => visitor.visit_ident(name),
+        ExprKind::Variable(path) => visitor.visit_path(path),
         ExprKind::Call { fun, args } => {
             visitor.visit_expr(fun);
 

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -8,7 +8,7 @@ pub use error::*;
 use thin_vec::ThinVec;
 use tracing::trace;
 
-use crate::ast::{Ident, Item, Span};
+use crate::ast::{Ident, Item, Path, PathSegment, Span, DUMMY_SPAN};
 use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
 
@@ -230,6 +230,24 @@ where
         self.advance();
 
         Ok(ident)
+    }
+
+    /// Parses a [`Path`].
+    fn parse_path(&mut self) -> ParseResult<Path> {
+        let mut path_segments = ThinVec::new();
+
+        while let Some(ident) = self.parse_ident().ok() {
+            path_segments.push(PathSegment { ident });
+
+            if !self.consume(TokenKind::ColonColon) {
+                break;
+            }
+        }
+
+        Ok(Path {
+            segments: path_segments,
+            span: DUMMY_SPAN,
+        })
     }
 }
 

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -244,9 +244,21 @@ where
             }
         }
 
+        let span = {
+            let start_span = path_segments.first().map(|segment| segment.ident.span);
+            let end_span = path_segments.last().map(|segment| segment.ident.span);
+
+            match (start_span, end_span) {
+                (Some(start), Some(end)) => start.to(end),
+                (Some(span), None) | (None, Some(span)) => span,
+                // TODO: Is this case impossible?
+                (None, None) => DUMMY_SPAN,
+            }
+        };
+
         Ok(Path {
             segments: path_segments,
-            span: DUMMY_SPAN,
+            span,
         })
     }
 }

--- a/crates/crane/src/parser/expr.rs
+++ b/crates/crane/src/parser/expr.rs
@@ -40,13 +40,13 @@ where
         }
 
         if self.check_without_expect(TokenKind::Ident) {
-            let ident = self.parse_ident()?;
+            let path = self.parse_path()?;
 
             if self.check_without_expect(TokenKind::OpenParen) {
-                let span = ident.span;
+                let span = path.span;
 
                 let callee = Expr {
-                    kind: ExprKind::Variable { name: ident },
+                    kind: ExprKind::Variable(path),
                     span,
                 };
 
@@ -60,10 +60,10 @@ where
                     span,
                 }));
             } else {
-                let span = ident.span;
+                let span = path.span;
 
                 return Ok(Some(Expr {
-                    kind: ExprKind::Variable { name: ident },
+                    kind: ExprKind::Variable(path),
                     span,
                 }));
             }

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
@@ -16,11 +16,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 16
-                              end: 23
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 16
+                                  end: 23
+                          span:
+                            start: 16
+                            end: 23
                       span:
                         start: 16
                         end: 23
@@ -30,11 +34,15 @@ Ok:
                             fun:
                               kind:
                                 Variable:
-                                  name:
-                                    name: int_to_string
-                                    span:
-                                      start: 24
-                                      end: 37
+                                  segments:
+                                    - ident:
+                                        name: int_to_string
+                                        span:
+                                          start: 24
+                                          end: 37
+                                  span:
+                                    start: 24
+                                    end: 37
                               span:
                                 start: 24
                                 end: 37
@@ -44,11 +52,15 @@ Ok:
                                     fun:
                                       kind:
                                         Variable:
-                                          name:
-                                            name: add_10
-                                            span:
-                                              start: 38
-                                              end: 44
+                                          segments:
+                                            - ident:
+                                                name: add_10
+                                                span:
+                                                  start: 38
+                                                  end: 44
+                                          span:
+                                            start: 38
+                                            end: 44
                                       span:
                                         start: 38
                                         end: 44
@@ -106,22 +118,30 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: int_add
-                            span:
-                              start: 90
-                              end: 97
+                          segments:
+                            - ident:
+                                name: int_add
+                                span:
+                                  start: 90
+                                  end: 97
+                          span:
+                            start: 90
+                            end: 97
                       span:
                         start: 90
                         end: 97
                     args:
                       - kind:
                           Variable:
-                            name:
-                              name: n
-                              span:
-                                start: 98
-                                end: 99
+                            segments:
+                              - ident:
+                                  name: n
+                                  span:
+                                    start: 98
+                                    end: 99
+                            span:
+                              start: 98
+                              end: 99
                         span:
                           start: 98
                           end: 99

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
@@ -16,11 +16,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: say_hello
-                            span:
-                              start: 20
-                              end: 29
+                          segments:
+                            - ident:
+                                name: say_hello
+                                span:
+                                  start: 20
+                                  end: 29
+                          span:
+                            start: 20
+                            end: 29
                       span:
                         start: 20
                         end: 29
@@ -38,11 +42,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: say_goodbye
-                            span:
-                              start: 36
-                              end: 47
+                          segments:
+                            - ident:
+                                name: say_goodbye
+                                span:
+                                  start: 36
+                                  end: 47
+                          span:
+                            start: 36
+                            end: 47
                       span:
                         start: 36
                         end: 47
@@ -70,11 +78,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 74
-                              end: 81
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 74
+                                  end: 81
+                          span:
+                            start: 74
+                            end: 81
                       span:
                         start: 74
                         end: 81
@@ -109,11 +121,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 117
-                              end: 124
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 117
+                                  end: 124
+                          span:
+                            start: 117
+                            end: 124
                       span:
                         start: 117
                         end: 124

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
@@ -16,11 +16,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 70
-                              end: 77
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 70
+                                  end: 77
+                          span:
+                            start: 70
+                            end: 77
                       span:
                         start: 70
                         end: 77

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -62,11 +62,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: print
-                            span:
-                              start: 62
-                              end: 67
+                          segments:
+                            - ident:
+                                name: print
+                                span:
+                                  start: 62
+                                  end: 67
+                          span:
+                            start: 62
+                            end: 67
                       span:
                         start: 62
                         end: 67
@@ -91,22 +95,30 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: print
-                            span:
-                              start: 83
-                              end: 88
+                          segments:
+                            - ident:
+                                name: print
+                                span:
+                                  start: 83
+                                  end: 88
+                          span:
+                            start: 83
+                            end: 88
                       span:
                         start: 83
                         end: 88
                     args:
                       - kind:
                           Variable:
-                            name:
-                              name: name
-                              span:
-                                start: 89
-                                end: 93
+                            segments:
+                              - ident:
+                                  name: name
+                                  span:
+                                    start: 89
+                                    end: 93
+                            span:
+                              start: 89
+                              end: 93
                         span:
                           start: 89
                           end: 93
@@ -123,11 +135,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 99
-                              end: 106
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 99
+                                  end: 106
+                          span:
+                            start: 99
+                            end: 106
                       span:
                         start: 99
                         end: 106
@@ -152,11 +168,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: print
-                            span:
-                              start: 117
-                              end: 122
+                          segments:
+                            - ident:
+                                name: print
+                                span:
+                                  start: 117
+                                  end: 122
+                          span:
+                            start: 117
+                            end: 122
                       span:
                         start: 117
                         end: 122
@@ -181,11 +201,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: print
-                            span:
-                              start: 150
-                              end: 155
+                          segments:
+                            - ident:
+                                name: print
+                                span:
+                                  start: 150
+                                  end: 155
+                          span:
+                            start: 150
+                            end: 155
                       span:
                         start: 150
                         end: 155
@@ -195,22 +219,30 @@ Ok:
                             fun:
                               kind:
                                 Variable:
-                                  name:
-                                    name: int_to_string
-                                    span:
-                                      start: 156
-                                      end: 169
+                                  segments:
+                                    - ident:
+                                        name: int_to_string
+                                        span:
+                                          start: 156
+                                          end: 169
+                                  span:
+                                    start: 156
+                                    end: 169
                               span:
                                 start: 156
                                 end: 169
                             args:
                               - kind:
                                   Variable:
-                                    name:
-                                      name: gold
-                                      span:
-                                        start: 170
-                                        end: 174
+                                    segments:
+                                      - ident:
+                                          name: gold
+                                          span:
+                                            start: 170
+                                            end: 174
+                                    span:
+                                      start: 170
+                                      end: 174
                                 span:
                                   start: 170
                                   end: 174
@@ -230,11 +262,15 @@ Ok:
                     fun:
                       kind:
                         Variable:
-                          name:
-                            name: println
-                            span:
-                              start: 181
-                              end: 188
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 181
+                                  end: 188
+                          span:
+                            start: 181
+                            end: 188
                       span:
                         start: 181
                         end: 188

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -380,7 +380,15 @@ impl Typer {
                 LiteralKind::String => self.infer_string(literal, expr.span),
                 LiteralKind::Integer => self.infer_integer(literal, expr.span),
             },
-            ExprKind::Variable { name } => {
+            ExprKind::Variable(path) => {
+                // HACK: Read the last path segment as the variable name.
+                let name = path
+                    .segments
+                    .last()
+                    .expect("Path has no segments.")
+                    .ident
+                    .clone();
+
                 let ty = self
                     .scopes
                     .last()

--- a/examples/hello_world.crane
+++ b/examples/hello_world.crane
@@ -2,5 +2,5 @@
 // use std::io::println
 
 pub fn main() {
-    println("Hello, world!")
+    std::io::println("Hello, world!")
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -27,7 +27,7 @@ pub fn main() {
     greet("world")
     greet("trees")
     greet("everyone")
-    println("")
+    std::io::println("")
 
     print("This value is always ")
     println(int_to_string(always_3()))


### PR DESCRIPTION
This PR updates the `ExprKind::Variable` to use a `Path` instead of a plain `Ident` to refer to variables.

Note that for now we still just use the last path segment as the name in the typer/backend.