### PR TITLE
Use paths in typed AST

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -259,16 +259,16 @@ mod tests {
 
         #[cfg(target_arch = "x86_64")]
         {
-            // For whatever reason, `TyExpr` is a slightly smaller size on x86_64.
             insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"64");
+            insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"40");
         }
 
         #[cfg(target_arch = "aarch64")]
         {
             insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"80");
+            insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
         }
 
-        insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -260,7 +260,7 @@ mod tests {
         #[cfg(target_arch = "x86_64")]
         {
             // For whatever reason, `TyExpr` is a slightly smaller size on x86_64.
-            insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"72");
+            insta::assert_snapshot!(size_of::<TyExpr>().to_string(), @"64");
         }
 
         #[cfg(target_arch = "aarch64")]

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -269,7 +269,7 @@ mod tests {
         }
 
         insta::assert_snapshot!(size_of::<TyExprKind>().to_string(), @"48");
-        insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"24");
+        insta::assert_snapshot!(size_of::<TyFn>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<TyItem>().to_string(), @"56");
         insta::assert_snapshot!(size_of::<TyItemKind>().to_string(), @"16");
         insta::assert_snapshot!(size_of::<TyStmt>().to_string(), @"32");

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -137,6 +137,10 @@ pub struct TyFn {
     pub params: ThinVec<TyFnParam>,
     pub return_ty: Arc<Type>,
     pub body: ThinVec<TyStmt>,
+
+    // HACK: Adding this to the node so we don't have to recompute the path in
+    // the backend. Should find a better way of doing this.
+    pub path: TyPath,
 }
 
 /// A parameter to a [`TyFn`].

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -134,9 +134,9 @@ impl NativeBackend {
             fn_name
         };
 
-        // Define `print`.
+        // Define `std::io::print`.
         {
-            let fn_name = "print";
+            let fn_name = "std::io::print";
 
             let i8_type = self.context.i8_type();
 
@@ -183,9 +183,9 @@ impl NativeBackend {
             Self::verify_fn(&fpm, fn_name, &fn_value).unwrap();
         }
 
-        // Define `println`.
+        // Define `std::io::println`.
         {
-            let fn_name = "println";
+            let fn_name = "std::io::println";
 
             let i8_type = self.context.i8_type();
 
@@ -216,9 +216,9 @@ impl NativeBackend {
             Self::verify_fn(&fpm, fn_name, &fn_value).unwrap();
         }
 
-        // Define `int_add`.
+        // Define `std::int::int_add`.
         {
-            let fn_name = "int_add";
+            let fn_name = "std::int::int_add";
 
             let i64_type = self.context.i64_type();
 
@@ -246,9 +246,9 @@ impl NativeBackend {
             Self::verify_fn(&fpm, fn_name, &fn_value).unwrap();
         }
 
-        // Define `int_to_string`.
+        // Define `std::int::int_to_string`.
         {
-            let fn_name = "int_to_string";
+            let fn_name = "std::int::int_to_string";
 
             let i64_type = self.context.i64_type();
             let i8_type = self.context.i8_type();

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -299,10 +299,13 @@ impl NativeBackend {
             Self::verify_fn(&fpm, fn_name, &fn_value).unwrap();
         }
 
-        for item in package.modules.into_iter().flat_map(|module| module.items)
-        // HACK: Reverse the items so we define the helper functions before `main`.
-        // This should be replaced with a call graph.
-        // .rev()
+        for item in package
+            .modules
+            .into_iter()
+            .flat_map(|module| module.items)
+            // HACK: Reverse the items so we define the helper functions before `main`.
+            // This should be replaced with a call graph.
+            .rev()
         {
             Self::compile_item(&self.context, &builder, &module, &fpm, &item);
         }
@@ -338,8 +341,6 @@ impl NativeBackend {
         fn_name: &str,
         fn_value: &FunctionValue,
     ) -> Result<(), String> {
-        tracing::trace!("Verifying function {}", fn_name);
-
         if fn_value.verify(true) {
             fpm.run_on(fn_value);
 
@@ -368,8 +369,6 @@ impl NativeBackend {
         fpm: &PassManager<FunctionValue<'ctx>>,
         item: &TyItem,
     ) {
-        tracing::trace!("Compiling item {}", item.name);
-
         match &item.kind {
             TyItemKind::Use => {}
             TyItemKind::Fn(fun) => {
@@ -427,7 +426,7 @@ impl NativeBackend {
                     fn_type
                 };
 
-                let fn_value = module.add_function(&item.name.to_string(), fn_type, None);
+                let fn_value = module.add_function(&fun.path.to_string(), fn_type, None);
 
                 for (index, param_value) in fn_value.get_param_iter().enumerate() {
                     if let Some(param) = fun.params.get(index) {

--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -140,12 +140,12 @@ fn compile(example: Option<String>) -> Result<(), ()> {
                     let example_file = example_file.display().to_string();
 
                     let error_report = match type_error.kind {
-                        TypeErrorKind::UnknownFunction { name } => {
+                        TypeErrorKind::UnknownFunction(path) => {
                             Report::build(ReportKind::Error, &example_file, 1)
                                 .with_message("A type error occurred.")
                                 .with_label(
                                     Label::new(SourceSpan::from((&example_file, span)))
-                                        .with_message(format!("Function `{name}` does not exist."))
+                                        .with_message(format!("Function `{path}` does not exist.",))
                                         .with_color(Color::Red),
                                 )
                                 .finish()

--- a/crates/crane/src/snapshot_inputs/function_return_types.crane
+++ b/crates/crane/src/snapshot_inputs/function_return_types.crane
@@ -1,7 +1,7 @@
 fn main() {
-    println(int_to_string(add_10(5)))
+    std::io::println(std::int::int_to_string(add_10(5)))
 }
 
 fn add_10(n: Uint64) -> Uint64 {
-    int_add(n, 10)
+    std::int::int_add(n, 10)
 }

--- a/crates/crane/src/snapshot_inputs/functions.crane
+++ b/crates/crane/src/snapshot_inputs/functions.crane
@@ -4,9 +4,9 @@ pub fn main() {
 }
 
 fn say_hello() {
-    println("Hello")
+    std::io::println("Hello")
 }
 
 fn say_goodbye() {
-    println("Goodbye")
+    std::io::println("Goodbye")
 }

--- a/crates/crane/src/snapshot_inputs/hello_world.crane
+++ b/crates/crane/src/snapshot_inputs/hello_world.crane
@@ -2,5 +2,5 @@
 // use std::io::println
 
 pub fn main() {
-    println("Hello, world!")
+    std::io::println("Hello, world!")
 }

--- a/crates/crane/src/snapshot_inputs/let_bindings.crane
+++ b/crates/crane/src/snapshot_inputs/let_bindings.crane
@@ -7,6 +7,6 @@ pub fn main() {
     std::io::println(".")
 
     std::io::print("You currently have ")
-    std::io::print(int_to_string(gold))
+    std::io::print(std::int::int_to_string(gold))
     std::io::println(" gold at your disposal.")
 }

--- a/crates/crane/src/snapshot_inputs/let_bindings.crane
+++ b/crates/crane/src/snapshot_inputs/let_bindings.crane
@@ -2,11 +2,11 @@ pub fn main() {
     let name = "Arya"
     let gold = 100
 
-    print("Hello, ")
-    print(name)
-    println(".")
+    std::io::print("Hello, ")
+    std::io::print(name)
+    std::io::println(".")
 
-    print("You currently have ")
-    print(int_to_string(gold))
-    println(" gold at your disposal.")
+    std::io::print("You currently have ")
+    std::io::print(int_to_string(gold))
+    std::io::println(" gold at your disposal.")
 }

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@function_return_types.crane.snap
@@ -35,170 +35,242 @@ input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
       end: 11
 - Ok:
     kind: Ident
-    lexeme: println
+    lexeme: std
     span:
       start: 16
+      end: 19
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 19
+      end: 21
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 21
       end: 23
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 23
+      end: 25
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 25
+      end: 32
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 23
-      end: 24
+      start: 32
+      end: 33
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 33
+      end: 36
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 36
+      end: 38
+- Ok:
+    kind: Ident
+    lexeme: int
+    span:
+      start: 38
+      end: 41
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 41
+      end: 43
 - Ok:
     kind: Ident
     lexeme: int_to_string
     span:
-      start: 24
-      end: 37
+      start: 43
+      end: 56
 - Ok:
     kind: OpenParen
     lexeme: (
-    span:
-      start: 37
-      end: 38
-- Ok:
-    kind: Ident
-    lexeme: add_10
-    span:
-      start: 38
-      end: 44
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 44
-      end: 45
-- Ok:
-    kind: Integer
-    lexeme: "5"
-    span:
-      start: 45
-      end: 46
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 46
-      end: 47
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 47
-      end: 48
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 48
-      end: 49
-- Ok:
-    kind: CloseBrace
-    lexeme: "}"
-    span:
-      start: 50
-      end: 51
-- Ok:
-    kind: Ident
-    lexeme: fn
-    span:
-      start: 53
-      end: 55
-- Ok:
-    kind: Ident
-    lexeme: add_10
     span:
       start: 56
-      end: 62
+      end: 57
+- Ok:
+    kind: Ident
+    lexeme: add_10
+    span:
+      start: 57
+      end: 63
 - Ok:
     kind: OpenParen
     lexeme: (
-    span:
-      start: 62
-      end: 63
-- Ok:
-    kind: Ident
-    lexeme: n
     span:
       start: 63
       end: 64
 - Ok:
-    kind: Colon
-    lexeme: ":"
+    kind: Integer
+    lexeme: "5"
     span:
       start: 64
       end: 65
 - Ok:
-    kind: Ident
-    lexeme: Uint64
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 65
+      end: 66
+- Ok:
+    kind: CloseParen
+    lexeme: )
     span:
       start: 66
-      end: 72
+      end: 67
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 72
-      end: 73
-- Ok:
-    kind: RightArrow
-    lexeme: "->"
-    span:
-      start: 74
-      end: 76
-- Ok:
-    kind: Ident
-    lexeme: Uint64
-    span:
-      start: 77
-      end: 83
-- Ok:
-    kind: OpenBrace
-    lexeme: "{"
-    span:
-      start: 84
-      end: 85
-- Ok:
-    kind: Ident
-    lexeme: int_add
-    span:
-      start: 90
-      end: 97
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 97
-      end: 98
-- Ok:
-    kind: Ident
-    lexeme: n
-    span:
-      start: 98
-      end: 99
-- Ok:
-    kind: Comma
-    lexeme: ","
-    span:
-      start: 99
-      end: 100
-- Ok:
-    kind: Integer
-    lexeme: "10"
-    span:
-      start: 101
-      end: 103
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 103
-      end: 104
+      start: 67
+      end: 68
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 105
-      end: 106
+      start: 69
+      end: 70
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 72
+      end: 74
+- Ok:
+    kind: Ident
+    lexeme: add_10
+    span:
+      start: 75
+      end: 81
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 81
+      end: 82
+- Ok:
+    kind: Ident
+    lexeme: n
+    span:
+      start: 82
+      end: 83
+- Ok:
+    kind: Colon
+    lexeme: ":"
+    span:
+      start: 83
+      end: 84
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 85
+      end: 91
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 91
+      end: 92
+- Ok:
+    kind: RightArrow
+    lexeme: "->"
+    span:
+      start: 93
+      end: 95
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 96
+      end: 102
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 103
+      end: 104
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 109
+      end: 112
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 112
+      end: 114
+- Ok:
+    kind: Ident
+    lexeme: int
+    span:
+      start: 114
+      end: 117
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 117
+      end: 119
+- Ok:
+    kind: Ident
+    lexeme: int_add
+    span:
+      start: 119
+      end: 126
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 126
+      end: 127
+- Ok:
+    kind: Ident
+    lexeme: n
+    span:
+      start: 127
+      end: 128
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 128
+      end: 129
+- Ok:
+    kind: Integer
+    lexeme: "10"
+    span:
+      start: 130
+      end: 132
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 132
+      end: 133
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 134
+      end: 135
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@functions.crane.snap
@@ -113,92 +113,140 @@ input_file: crates/crane/src/snapshot_inputs/functions.crane
       end: 69
 - Ok:
     kind: Ident
-    lexeme: println
+    lexeme: std
     span:
       start: 74
+      end: 77
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 77
+      end: 79
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 79
       end: 81
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 81
+      end: 83
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 83
+      end: 90
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 81
-      end: 82
+      start: 90
+      end: 91
 - Ok:
     kind: String
     lexeme: "\"Hello\""
     span:
-      start: 82
-      end: 89
+      start: 91
+      end: 98
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 89
-      end: 90
+      start: 98
+      end: 99
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 91
-      end: 92
+      start: 100
+      end: 101
 - Ok:
     kind: Ident
     lexeme: fn
     span:
-      start: 94
-      end: 96
+      start: 103
+      end: 105
 - Ok:
     kind: Ident
     lexeme: say_goodbye
     span:
-      start: 97
-      end: 108
+      start: 106
+      end: 117
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 108
-      end: 109
+      start: 117
+      end: 118
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 109
-      end: 110
+      start: 118
+      end: 119
 - Ok:
     kind: OpenBrace
     lexeme: "{"
     span:
-      start: 111
-      end: 112
+      start: 120
+      end: 121
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 126
+      end: 129
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 129
+      end: 131
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 131
+      end: 133
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 133
+      end: 135
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 117
-      end: 124
+      start: 135
+      end: 142
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 124
-      end: 125
+      start: 142
+      end: 143
 - Ok:
     kind: String
     lexeme: "\"Goodbye\""
     span:
-      start: 125
-      end: 134
+      start: 143
+      end: 152
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 134
-      end: 135
+      start: 152
+      end: 153
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 136
-      end: 137
+      start: 154
+      end: 155
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@hello_world.crane.snap
@@ -53,32 +53,56 @@ input_file: crates/crane/src/snapshot_inputs/hello_world.crane
       end: 65
 - Ok:
     kind: Ident
-    lexeme: println
+    lexeme: std
     span:
       start: 70
+      end: 73
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 73
+      end: 75
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 75
       end: 77
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 77
+      end: 79
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 79
+      end: 86
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 77
-      end: 78
+      start: 86
+      end: 87
 - Ok:
     kind: String
     lexeme: "\"Hello, world!\""
     span:
-      start: 78
-      end: 93
+      start: 87
+      end: 102
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 93
-      end: 94
+      start: 102
+      end: 103
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 95
-      end: 96
+      start: 104
+      end: 105
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
@@ -317,86 +317,110 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
       end: 201
 - Ok:
     kind: Ident
-    lexeme: int_to_string
+    lexeme: std
     span:
       start: 201
-      end: 214
+      end: 204
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 204
+      end: 206
+- Ok:
+    kind: Ident
+    lexeme: int
+    span:
+      start: 206
+      end: 209
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 209
+      end: 211
+- Ok:
+    kind: Ident
+    lexeme: int_to_string
+    span:
+      start: 211
+      end: 224
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 214
-      end: 215
+      start: 224
+      end: 225
 - Ok:
     kind: Ident
     lexeme: gold
     span:
-      start: 215
-      end: 219
+      start: 225
+      end: 229
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 219
-      end: 220
+      start: 229
+      end: 230
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 220
-      end: 221
+      start: 230
+      end: 231
 - Ok:
     kind: Ident
     lexeme: std
     span:
-      start: 226
-      end: 229
+      start: 236
+      end: 239
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 229
-      end: 231
+      start: 239
+      end: 241
 - Ok:
     kind: Ident
     lexeme: io
     span:
-      start: 231
-      end: 233
+      start: 241
+      end: 243
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 233
-      end: 235
+      start: 243
+      end: 245
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 235
-      end: 242
+      start: 245
+      end: 252
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 242
-      end: 243
+      start: 252
+      end: 253
 - Ok:
     kind: String
     lexeme: "\" gold at your disposal.\""
     span:
-      start: 243
-      end: 268
+      start: 253
+      end: 278
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 268
-      end: 269
+      start: 278
+      end: 279
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 270
-      end: 271
+      start: 280
+      end: 281
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
@@ -89,57 +89,81 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
       end: 56
 - Ok:
     kind: Ident
-    lexeme: print
+    lexeme: std
     span:
       start: 62
+      end: 65
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 65
       end: 67
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 67
+      end: 69
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 69
+      end: 71
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 71
+      end: 76
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 67
-      end: 68
+      start: 76
+      end: 77
 - Ok:
     kind: String
     lexeme: "\"Hello, \""
     span:
-      start: 68
-      end: 77
+      start: 77
+      end: 86
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 77
-      end: 78
+      start: 86
+      end: 87
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 92
+      end: 95
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 95
+      end: 97
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 97
+      end: 99
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 99
+      end: 101
 - Ok:
     kind: Ident
     lexeme: print
     span:
-      start: 83
-      end: 88
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 88
-      end: 89
-- Ok:
-    kind: Ident
-    lexeme: name
-    span:
-      start: 89
-      end: 93
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 93
-      end: 94
-- Ok:
-    kind: Ident
-    lexeme: println
-    span:
-      start: 99
+      start: 101
       end: 106
 - Ok:
     kind: OpenParen
@@ -148,111 +172,231 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
       start: 106
       end: 107
 - Ok:
-    kind: String
-    lexeme: "\".\""
+    kind: Ident
+    lexeme: name
     span:
       start: 107
-      end: 110
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 110
       end: 111
 - Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 111
+      end: 112
+- Ok:
     kind: Ident
-    lexeme: print
+    lexeme: std
     span:
       start: 117
+      end: 120
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 120
       end: 122
 - Ok:
-    kind: OpenParen
-    lexeme: (
+    kind: Ident
+    lexeme: io
     span:
       start: 122
-      end: 123
+      end: 124
 - Ok:
-    kind: String
-    lexeme: "\"You currently have \""
+    kind: ColonColon
+    lexeme: "::"
     span:
-      start: 123
-      end: 144
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 144
-      end: 145
-- Ok:
-    kind: Ident
-    lexeme: print
-    span:
-      start: 150
-      end: 155
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 155
-      end: 156
-- Ok:
-    kind: Ident
-    lexeme: int_to_string
-    span:
-      start: 156
-      end: 169
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 169
-      end: 170
-- Ok:
-    kind: Ident
-    lexeme: gold
-    span:
-      start: 170
-      end: 174
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 174
-      end: 175
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 175
-      end: 176
+      start: 124
+      end: 126
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 181
-      end: 188
+      start: 126
+      end: 133
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 188
-      end: 189
+      start: 133
+      end: 134
 - Ok:
     kind: String
-    lexeme: "\" gold at your disposal.\""
+    lexeme: "\".\""
     span:
-      start: 189
-      end: 214
+      start: 134
+      end: 137
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
+      start: 137
+      end: 138
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 144
+      end: 147
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 147
+      end: 149
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 149
+      end: 151
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 151
+      end: 153
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 153
+      end: 158
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 158
+      end: 159
+- Ok:
+    kind: String
+    lexeme: "\"You currently have \""
+    span:
+      start: 159
+      end: 180
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 180
+      end: 181
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 186
+      end: 189
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 189
+      end: 191
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 191
+      end: 193
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 193
+      end: 195
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 195
+      end: 200
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 200
+      end: 201
+- Ok:
+    kind: Ident
+    lexeme: int_to_string
+    span:
+      start: 201
+      end: 214
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
       start: 214
       end: 215
+- Ok:
+    kind: Ident
+    lexeme: gold
+    span:
+      start: 215
+      end: 219
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 219
+      end: 220
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 220
+      end: 221
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 226
+      end: 229
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 229
+      end: 231
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 231
+      end: 233
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 233
+      end: 235
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 235
+      end: 242
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 242
+      end: 243
+- Ok:
+    kind: String
+    lexeme: "\" gold at your disposal.\""
+    span:
+      start: 243
+      end: 268
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 268
+      end: 269
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 216
-      end: 217
+      start: 270
+      end: 271
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
@@ -18,16 +18,26 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: println
+                                name: std
                                 span:
                                   start: 16
+                                  end: 19
+                            - ident:
+                                name: io
+                                span:
+                                  start: 21
                                   end: 23
+                            - ident:
+                                name: println
+                                span:
+                                  start: 25
+                                  end: 32
                           span:
                             start: 16
-                            end: 23
+                            end: 32
                       span:
                         start: 16
-                        end: 23
+                        end: 32
                     args:
                       - kind:
                           Call:
@@ -36,16 +46,26 @@ Ok:
                                 Variable:
                                   segments:
                                     - ident:
+                                        name: std
+                                        span:
+                                          start: 33
+                                          end: 36
+                                    - ident:
+                                        name: int
+                                        span:
+                                          start: 38
+                                          end: 41
+                                    - ident:
                                         name: int_to_string
                                         span:
-                                          start: 24
-                                          end: 37
+                                          start: 43
+                                          end: 56
                                   span:
-                                    start: 24
-                                    end: 37
+                                    start: 33
+                                    end: 56
                               span:
-                                start: 24
-                                end: 37
+                                start: 33
+                                end: 56
                             args:
                               - kind:
                                   Call:
@@ -56,34 +76,34 @@ Ok:
                                             - ident:
                                                 name: add_10
                                                 span:
-                                                  start: 38
-                                                  end: 44
+                                                  start: 57
+                                                  end: 63
                                           span:
-                                            start: 38
-                                            end: 44
+                                            start: 57
+                                            end: 63
                                       span:
-                                        start: 38
-                                        end: 44
+                                        start: 57
+                                        end: 63
                                     args:
                                       - kind:
                                           Literal:
                                             kind: Integer
                                             value: "5"
                                         span:
-                                          start: 45
-                                          end: 46
+                                          start: 64
+                                          end: 65
                                 span:
-                                  start: 38
-                                  end: 44
+                                  start: 57
+                                  end: 63
                         span:
-                          start: 24
-                          end: 37
+                          start: 33
+                          end: 56
                 span:
                   start: 16
-                  end: 23
+                  end: 32
             span:
               start: 16
-              end: 23
+              end: 32
     name:
       name: main
       span:
@@ -95,21 +115,21 @@ Ok:
           - name:
               name: n
               span:
-                start: 63
-                end: 64
+                start: 82
+                end: 83
             ty:
               name: Uint64
               span:
-                start: 66
-                end: 72
+                start: 85
+                end: 91
             span:
-              start: 63
-              end: 64
+              start: 82
+              end: 83
         return_ty:
           name: Uint64
           span:
-            start: 77
-            end: 83
+            start: 96
+            end: 102
         body:
           - kind:
               Expr:
@@ -120,16 +140,26 @@ Ok:
                         Variable:
                           segments:
                             - ident:
+                                name: std
+                                span:
+                                  start: 109
+                                  end: 112
+                            - ident:
+                                name: int
+                                span:
+                                  start: 114
+                                  end: 117
+                            - ident:
                                 name: int_add
                                 span:
-                                  start: 90
-                                  end: 97
+                                  start: 119
+                                  end: 126
                           span:
-                            start: 90
-                            end: 97
+                            start: 109
+                            end: 126
                       span:
-                        start: 90
-                        end: 97
+                        start: 109
+                        end: 126
                     args:
                       - kind:
                           Variable:
@@ -137,30 +167,30 @@ Ok:
                               - ident:
                                   name: n
                                   span:
-                                    start: 98
-                                    end: 99
+                                    start: 127
+                                    end: 128
                             span:
-                              start: 98
-                              end: 99
+                              start: 127
+                              end: 128
                         span:
-                          start: 98
-                          end: 99
+                          start: 127
+                          end: 128
                       - kind:
                           Literal:
                             kind: Integer
                             value: "10"
                         span:
-                          start: 101
-                          end: 103
+                          start: 130
+                          end: 132
                 span:
-                  start: 90
-                  end: 97
+                  start: 109
+                  end: 126
             span:
-              start: 90
-              end: 97
+              start: 109
+              end: 126
     name:
       name: add_10
       span:
-        start: 56
-        end: 62
+        start: 75
+        end: 81
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
@@ -80,30 +80,40 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: println
+                                name: std
                                 span:
                                   start: 74
+                                  end: 77
+                            - ident:
+                                name: io
+                                span:
+                                  start: 79
                                   end: 81
+                            - ident:
+                                name: println
+                                span:
+                                  start: 83
+                                  end: 90
                           span:
                             start: 74
-                            end: 81
+                            end: 90
                       span:
                         start: 74
-                        end: 81
+                        end: 90
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello\""
                         span:
-                          start: 82
-                          end: 89
+                          start: 91
+                          end: 98
                 span:
                   start: 74
-                  end: 81
+                  end: 90
             span:
               start: 74
-              end: 81
+              end: 90
     name:
       name: say_hello
       span:
@@ -123,33 +133,43 @@ Ok:
                         Variable:
                           segments:
                             - ident:
+                                name: std
+                                span:
+                                  start: 126
+                                  end: 129
+                            - ident:
+                                name: io
+                                span:
+                                  start: 131
+                                  end: 133
+                            - ident:
                                 name: println
                                 span:
-                                  start: 117
-                                  end: 124
+                                  start: 135
+                                  end: 142
                           span:
-                            start: 117
-                            end: 124
+                            start: 126
+                            end: 142
                       span:
-                        start: 117
-                        end: 124
+                        start: 126
+                        end: 142
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Goodbye\""
                         span:
-                          start: 125
-                          end: 134
+                          start: 143
+                          end: 152
                 span:
-                  start: 117
-                  end: 124
+                  start: 126
+                  end: 142
             span:
-              start: 117
-              end: 124
+              start: 126
+              end: 142
     name:
       name: say_goodbye
       span:
-        start: 97
-        end: 108
+        start: 106
+        end: 117
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
@@ -18,30 +18,40 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: println
+                                name: std
                                 span:
                                   start: 70
+                                  end: 73
+                            - ident:
+                                name: io
+                                span:
+                                  start: 75
                                   end: 77
+                            - ident:
+                                name: println
+                                span:
+                                  start: 79
+                                  end: 86
                           span:
                             start: 70
-                            end: 77
+                            end: 86
                       span:
                         start: 70
-                        end: 77
+                        end: 86
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello, world!\""
                         span:
-                          start: 78
-                          end: 93
+                          start: 87
+                          end: 102
                 span:
                   start: 70
-                  end: 77
+                  end: 86
             span:
               start: 70
-              end: 77
+              end: 86
     name:
       name: main
       span:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -64,30 +64,40 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: print
+                                name: std
                                 span:
                                   start: 62
-                                  end: 67
+                                  end: 65
+                            - ident:
+                                name: io
+                                span:
+                                  start: 67
+                                  end: 69
+                            - ident:
+                                name: print
+                                span:
+                                  start: 71
+                                  end: 76
                           span:
                             start: 62
-                            end: 67
+                            end: 76
                       span:
                         start: 62
-                        end: 67
+                        end: 76
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello, \""
                         span:
-                          start: 68
-                          end: 77
+                          start: 77
+                          end: 86
                 span:
                   start: 62
-                  end: 67
+                  end: 76
             span:
               start: 62
-              end: 67
+              end: 76
           - kind:
               Expr:
                 kind:
@@ -97,16 +107,26 @@ Ok:
                         Variable:
                           segments:
                             - ident:
+                                name: std
+                                span:
+                                  start: 92
+                                  end: 95
+                            - ident:
+                                name: io
+                                span:
+                                  start: 97
+                                  end: 99
+                            - ident:
                                 name: print
                                 span:
-                                  start: 83
-                                  end: 88
+                                  start: 101
+                                  end: 106
                           span:
-                            start: 83
-                            end: 88
+                            start: 92
+                            end: 106
                       span:
-                        start: 83
-                        end: 88
+                        start: 92
+                        end: 106
                     args:
                       - kind:
                           Variable:
@@ -114,52 +134,19 @@ Ok:
                               - ident:
                                   name: name
                                   span:
-                                    start: 89
-                                    end: 93
+                                    start: 107
+                                    end: 111
                             span:
-                              start: 89
-                              end: 93
-                        span:
-                          start: 89
-                          end: 93
-                span:
-                  start: 83
-                  end: 88
-            span:
-              start: 83
-              end: 88
-          - kind:
-              Expr:
-                kind:
-                  Call:
-                    fun:
-                      kind:
-                        Variable:
-                          segments:
-                            - ident:
-                                name: println
-                                span:
-                                  start: 99
-                                  end: 106
-                          span:
-                            start: 99
-                            end: 106
-                      span:
-                        start: 99
-                        end: 106
-                    args:
-                      - kind:
-                          Literal:
-                            kind: String
-                            value: "\".\""
+                              start: 107
+                              end: 111
                         span:
                           start: 107
-                          end: 110
+                          end: 111
                 span:
-                  start: 99
+                  start: 92
                   end: 106
             span:
-              start: 99
+              start: 92
               end: 106
           - kind:
               Expr:
@@ -170,30 +157,40 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: print
+                                name: std
                                 span:
                                   start: 117
-                                  end: 122
+                                  end: 120
+                            - ident:
+                                name: io
+                                span:
+                                  start: 122
+                                  end: 124
+                            - ident:
+                                name: println
+                                span:
+                                  start: 126
+                                  end: 133
                           span:
                             start: 117
-                            end: 122
+                            end: 133
                       span:
                         start: 117
-                        end: 122
+                        end: 133
                     args:
                       - kind:
                           Literal:
                             kind: String
-                            value: "\"You currently have \""
+                            value: "\".\""
                         span:
-                          start: 123
-                          end: 144
+                          start: 134
+                          end: 137
                 span:
                   start: 117
-                  end: 122
+                  end: 133
             span:
               start: 117
-              end: 122
+              end: 133
           - kind:
               Expr:
                 kind:
@@ -203,16 +200,69 @@ Ok:
                         Variable:
                           segments:
                             - ident:
+                                name: std
+                                span:
+                                  start: 144
+                                  end: 147
+                            - ident:
+                                name: io
+                                span:
+                                  start: 149
+                                  end: 151
+                            - ident:
                                 name: print
                                 span:
-                                  start: 150
-                                  end: 155
+                                  start: 153
+                                  end: 158
                           span:
-                            start: 150
-                            end: 155
+                            start: 144
+                            end: 158
                       span:
-                        start: 150
-                        end: 155
+                        start: 144
+                        end: 158
+                    args:
+                      - kind:
+                          Literal:
+                            kind: String
+                            value: "\"You currently have \""
+                        span:
+                          start: 159
+                          end: 180
+                span:
+                  start: 144
+                  end: 158
+            span:
+              start: 144
+              end: 158
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          segments:
+                            - ident:
+                                name: std
+                                span:
+                                  start: 186
+                                  end: 189
+                            - ident:
+                                name: io
+                                span:
+                                  start: 191
+                                  end: 193
+                            - ident:
+                                name: print
+                                span:
+                                  start: 195
+                                  end: 200
+                          span:
+                            start: 186
+                            end: 200
+                      span:
+                        start: 186
+                        end: 200
                     args:
                       - kind:
                           Call:
@@ -223,14 +273,14 @@ Ok:
                                     - ident:
                                         name: int_to_string
                                         span:
-                                          start: 156
-                                          end: 169
+                                          start: 201
+                                          end: 214
                                   span:
-                                    start: 156
-                                    end: 169
+                                    start: 201
+                                    end: 214
                               span:
-                                start: 156
-                                end: 169
+                                start: 201
+                                end: 214
                             args:
                               - kind:
                                   Variable:
@@ -238,23 +288,23 @@ Ok:
                                       - ident:
                                           name: gold
                                           span:
-                                            start: 170
-                                            end: 174
+                                            start: 215
+                                            end: 219
                                     span:
-                                      start: 170
-                                      end: 174
+                                      start: 215
+                                      end: 219
                                 span:
-                                  start: 170
-                                  end: 174
+                                  start: 215
+                                  end: 219
                         span:
-                          start: 156
-                          end: 169
+                          start: 201
+                          end: 214
                 span:
-                  start: 150
-                  end: 155
+                  start: 186
+                  end: 200
             span:
-              start: 150
-              end: 155
+              start: 186
+              end: 200
           - kind:
               Expr:
                 kind:
@@ -264,30 +314,40 @@ Ok:
                         Variable:
                           segments:
                             - ident:
+                                name: std
+                                span:
+                                  start: 226
+                                  end: 229
+                            - ident:
+                                name: io
+                                span:
+                                  start: 231
+                                  end: 233
+                            - ident:
                                 name: println
                                 span:
-                                  start: 181
-                                  end: 188
+                                  start: 235
+                                  end: 242
                           span:
-                            start: 181
-                            end: 188
+                            start: 226
+                            end: 242
                       span:
-                        start: 181
-                        end: 188
+                        start: 226
+                        end: 242
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\" gold at your disposal.\""
                         span:
-                          start: 189
-                          end: 214
+                          start: 243
+                          end: 268
                 span:
-                  start: 181
-                  end: 188
+                  start: 226
+                  end: 242
             span:
-              start: 181
-              end: 188
+              start: 226
+              end: 242
     name:
       name: main
       span:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -271,16 +271,26 @@ Ok:
                                 Variable:
                                   segments:
                                     - ident:
-                                        name: int_to_string
+                                        name: std
                                         span:
                                           start: 201
-                                          end: 214
+                                          end: 204
+                                    - ident:
+                                        name: int
+                                        span:
+                                          start: 206
+                                          end: 209
+                                    - ident:
+                                        name: int_to_string
+                                        span:
+                                          start: 211
+                                          end: 224
                                   span:
                                     start: 201
-                                    end: 214
+                                    end: 224
                               span:
                                 start: 201
-                                end: 214
+                                end: 224
                             args:
                               - kind:
                                   Variable:
@@ -288,17 +298,17 @@ Ok:
                                       - ident:
                                           name: gold
                                           span:
-                                            start: 215
-                                            end: 219
+                                            start: 225
+                                            end: 229
                                     span:
-                                      start: 215
-                                      end: 219
+                                      start: 225
+                                      end: 229
                                 span:
-                                  start: 215
-                                  end: 219
+                                  start: 225
+                                  end: 229
                         span:
                           start: 201
-                          end: 214
+                          end: 224
                 span:
                   start: 186
                   end: 200
@@ -316,38 +326,38 @@ Ok:
                             - ident:
                                 name: std
                                 span:
-                                  start: 226
-                                  end: 229
+                                  start: 236
+                                  end: 239
                             - ident:
                                 name: io
                                 span:
-                                  start: 231
-                                  end: 233
+                                  start: 241
+                                  end: 243
                             - ident:
                                 name: println
                                 span:
-                                  start: 235
-                                  end: 242
+                                  start: 245
+                                  end: 252
                           span:
-                            start: 226
-                            end: 242
+                            start: 236
+                            end: 252
                       span:
-                        start: 226
-                        end: 242
+                        start: 236
+                        end: 252
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\" gold at your disposal.\""
                         span:
-                          start: 243
-                          end: 268
+                          start: 253
+                          end: 278
                 span:
-                  start: 226
-                  end: 242
+                  start: 236
+                  end: 252
             span:
-              start: 226
-              end: 242
+              start: 236
+              end: 252
     name:
       name: main
       span:

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
@@ -1,204 +1,275 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
 ---
 Ok:
-  items:
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
-                              span:
-                                start: 16
-                                end: 23
-                        span:
-                          start: 16
-                          end: 23
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Call:
-                              fun:
-                                kind:
-                                  Variable:
-                                    name:
-                                      name: int_to_string
-                                      span:
-                                        start: 24
-                                        end: 37
-                                span:
-                                  start: 24
-                                  end: 37
-                                ty:
-                                  UserDefined:
-                                    module: "?"
-                                    name: "?"
-                              args:
-                                - kind:
-                                    Call:
-                                      fun:
-                                        kind:
-                                          Variable:
-                                            name:
-                                              name: add_10
-                                              span:
-                                                start: 38
-                                                end: 44
-                                        span:
-                                          start: 38
-                                          end: 44
-                                        ty:
-                                          UserDefined:
-                                            module: "?"
-                                            name: "?"
-                                      args:
-                                        - kind:
-                                            Literal:
-                                              kind:
-                                                Integer:
-                                                  Unsigned:
-                                                    - 5
-                                                    - Uint64
-                                              span:
-                                                start: 45
-                                                end: 46
-                                          span:
-                                            start: 45
-                                            end: 46
-                                          ty:
-                                            UserDefined:
-                                              module: "std::prelude"
-                                              name: Uint64
-                                  span:
-                                    start: 38
-                                    end: 44
-                                  ty:
-                                    UserDefined:
-                                      module: "std::prelude"
-                                      name: Uint64
-                          span:
-                            start: 24
-                            end: 37
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
-                  span:
-                    start: 16
-                    end: 23
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 16
-                end: 23
-      name:
-        name: main
-        span:
-          start: 3
-          end: 7
-    - kind:
-        Fn:
-          params:
-            - name:
-                name: n
-                span:
-                  start: 63
-                  end: 64
-              ty:
+  modules:
+    - items:
+        - kind:
+            Fn:
+              params: []
+              return_ty:
                 UserDefined:
                   module: "std::prelude"
-                  name: Uint64
-              span:
-                start: 63
-                end: 64
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: Uint64
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: int_add
-                              span:
-                                start: 90
-                                end: 97
-                        span:
-                          start: 90
-                          end: 97
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Variable:
-                              name:
-                                name: n
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 16
+                                        end: 19
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 21
+                                        end: 23
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 25
+                                        end: 32
                                 span:
-                                  start: 98
-                                  end: 99
-                          span:
-                            start: 98
-                            end: 99
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: Uint64
-                        - kind:
-                            Literal:
-                              kind:
-                                Integer:
-                                  Unsigned:
-                                    - 10
-                                    - Uint64
+                                  start: 16
+                                  end: 32
+                            span:
+                              start: 16
+                              end: 32
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Call:
+                                  fun:
+                                    kind:
+                                      Variable:
+                                        segments:
+                                          - ident:
+                                              name: std
+                                              span:
+                                                start: 33
+                                                end: 36
+                                          - ident:
+                                              name: int
+                                              span:
+                                                start: 38
+                                                end: 41
+                                          - ident:
+                                              name: int_to_string
+                                              span:
+                                                start: 43
+                                                end: 56
+                                        span:
+                                          start: 33
+                                          end: 56
+                                    span:
+                                      start: 33
+                                      end: 56
+                                    ty:
+                                      UserDefined:
+                                        module: "?"
+                                        name: "?"
+                                  args:
+                                    - kind:
+                                        Call:
+                                          fun:
+                                            kind:
+                                              Variable:
+                                                segments:
+                                                  - ident:
+                                                      name: add_10
+                                                      span:
+                                                        start: 57
+                                                        end: 63
+                                                span:
+                                                  start: 57
+                                                  end: 63
+                                            span:
+                                              start: 57
+                                              end: 63
+                                            ty:
+                                              UserDefined:
+                                                module: "?"
+                                                name: "?"
+                                          args:
+                                            - kind:
+                                                Literal:
+                                                  kind:
+                                                    Integer:
+                                                      Unsigned:
+                                                        - 5
+                                                        - Uint64
+                                                  span:
+                                                    start: 64
+                                                    end: 65
+                                              span:
+                                                start: 64
+                                                end: 65
+                                              ty:
+                                                UserDefined:
+                                                  module: "std::prelude"
+                                                  name: Uint64
+                                      span:
+                                        start: 57
+                                        end: 63
+                                      ty:
+                                        UserDefined:
+                                          module: "std::prelude"
+                                          name: Uint64
                               span:
-                                start: 101
-                                end: 103
-                          span:
-                            start: 101
-                            end: 103
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: Uint64
+                                start: 33
+                                end: 56
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 16
+                        end: 32
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
-                    start: 90
-                    end: 97
+                    start: 16
+                    end: 32
+              path:
+                segments:
+                  - ident:
+                      name: main
+                      span:
+                        start: 3
+                        end: 7
+                span:
+                  start: 3
+                  end: 7
+          name:
+            name: main
+            span:
+              start: 3
+              end: 7
+        - kind:
+            Fn:
+              params:
+                - name:
+                    name: n
+                    span:
+                      start: 82
+                      end: 83
                   ty:
                     UserDefined:
                       module: "std::prelude"
                       name: Uint64
-              span:
-                start: 90
-                end: 97
-      name:
-        name: add_10
-        span:
-          start: 56
-          end: 62
+                  span:
+                    start: 82
+                    end: 83
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: Uint64
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 109
+                                        end: 112
+                                  - ident:
+                                      name: int
+                                      span:
+                                        start: 114
+                                        end: 117
+                                  - ident:
+                                      name: int_add
+                                      span:
+                                        start: 119
+                                        end: 126
+                                span:
+                                  start: 109
+                                  end: 126
+                            span:
+                              start: 109
+                              end: 126
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Variable:
+                                  segments:
+                                    - ident:
+                                        name: n
+                                        span:
+                                          start: 127
+                                          end: 128
+                                  span:
+                                    start: 127
+                                    end: 128
+                              span:
+                                start: 127
+                                end: 128
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: Uint64
+                            - kind:
+                                Literal:
+                                  kind:
+                                    Integer:
+                                      Unsigned:
+                                        - 10
+                                        - Uint64
+                                  span:
+                                    start: 130
+                                    end: 132
+                              span:
+                                start: 130
+                                end: 132
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: Uint64
+                      span:
+                        start: 109
+                        end: 126
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: Uint64
+                  span:
+                    start: 109
+                    end: 126
+              path:
+                segments:
+                  - ident:
+                      name: add_10
+                      span:
+                        start: 75
+                        end: 81
+                span:
+                  start: 75
+                  end: 81
+          name:
+            name: add_10
+            span:
+              start: 75
+              end: 81
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
@@ -1,195 +1,262 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/functions.crane
 ---
 Ok:
-  items:
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: say_hello
-                              span:
-                                start: 20
-                                end: 29
-                        span:
-                          start: 20
-                          end: 29
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args: []
+  modules:
+    - items:
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: say_hello
+                                      span:
+                                        start: 20
+                                        end: 29
+                                span:
+                                  start: 20
+                                  end: 29
+                            span:
+                              start: 20
+                              end: 29
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args: []
+                      span:
+                        start: 20
+                        end: 29
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 20
                     end: 29
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 20
-                end: 29
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: say_goodbye
-                              span:
-                                start: 36
-                                end: 47
-                        span:
-                          start: 36
-                          end: 47
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args: []
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: say_goodbye
+                                      span:
+                                        start: 36
+                                        end: 47
+                                span:
+                                  start: 36
+                                  end: 47
+                            span:
+                              start: 36
+                              end: 47
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args: []
+                      span:
+                        start: 36
+                        end: 47
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 36
                     end: 47
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 36
-                end: 47
-      name:
-        name: main
-        span:
-          start: 7
-          end: 11
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
+              path:
+                segments:
+                  - ident:
+                      name: main
+                      span:
+                        start: 7
+                        end: 11
+                span:
+                  start: 7
+                  end: 11
+          name:
+            name: main
+            span:
+              start: 7
+              end: 11
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 74
+                                        end: 77
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 79
+                                        end: 81
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 83
+                                        end: 90
+                                span:
+                                  start: 74
+                                  end: 90
+                            span:
+                              start: 74
+                              end: 90
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\"Hello\""
+                                  span:
+                                    start: 91
+                                    end: 98
                               span:
-                                start: 74
-                                end: 81
-                        span:
-                          start: 74
-                          end: 81
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\"Hello\""
-                              span:
-                                start: 82
-                                end: 89
-                          span:
-                            start: 82
-                            end: 89
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 91
+                                end: 98
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 74
+                        end: 90
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 74
-                    end: 81
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 74
-                end: 81
-      name:
-        name: say_hello
-        span:
-          start: 56
-          end: 65
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
+                    end: 90
+              path:
+                segments:
+                  - ident:
+                      name: say_hello
+                      span:
+                        start: 56
+                        end: 65
+                span:
+                  start: 56
+                  end: 65
+          name:
+            name: say_hello
+            span:
+              start: 56
+              end: 65
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 126
+                                        end: 129
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 131
+                                        end: 133
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 135
+                                        end: 142
+                                span:
+                                  start: 126
+                                  end: 142
+                            span:
+                              start: 126
+                              end: 142
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\"Goodbye\""
+                                  span:
+                                    start: 143
+                                    end: 152
                               span:
-                                start: 117
-                                end: 124
-                        span:
-                          start: 117
-                          end: 124
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\"Goodbye\""
-                              span:
-                                start: 125
-                                end: 134
-                          span:
-                            start: 125
-                            end: 134
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 143
+                                end: 152
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 126
+                        end: 142
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
-                    start: 117
-                    end: 124
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 117
-                end: 124
-      name:
-        name: say_goodbye
-        span:
-          start: 97
-          end: 108
+                    start: 126
+                    end: 142
+              path:
+                segments:
+                  - ident:
+                      name: say_goodbye
+                      span:
+                        start: 106
+                        end: 117
+                span:
+                  start: 106
+                  end: 117
+          name:
+            name: say_goodbye
+            span:
+              start: 106
+              end: 117
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
@@ -1,65 +1,90 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/hello_world.crane
 ---
 Ok:
-  items:
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
+  modules:
+    - items:
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 70
+                                        end: 73
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 75
+                                        end: 77
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 79
+                                        end: 86
+                                span:
+                                  start: 70
+                                  end: 86
+                            span:
+                              start: 70
+                              end: 86
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\"Hello, world!\""
+                                  span:
+                                    start: 87
+                                    end: 102
                               span:
-                                start: 70
-                                end: 77
-                        span:
-                          start: 70
-                          end: 77
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\"Hello, world!\""
-                              span:
-                                start: 78
-                                end: 93
-                          span:
-                            start: 78
-                            end: 93
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 87
+                                end: 102
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 70
+                        end: 86
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 70
-                    end: 77
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 70
-                end: 77
-      name:
-        name: main
-        span:
-          start: 57
-          end: 61
+                    end: 86
+              path:
+                segments:
+                  - ident:
+                      name: main
+                      span:
+                        start: 57
+                        end: 61
+                span:
+                  start: 57
+                  end: 61
+          name:
+            name: main
+            span:
+              start: 57
+              end: 61
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
@@ -1,379 +1,496 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
 ---
 Ok:
-  items:
-    - kind:
-        Fn:
-          params: []
-          return_ty:
-            UserDefined:
-              module: "std::prelude"
-              name: ()
-          body:
-            - kind:
-                Local:
-                  kind:
-                    Init:
+  modules:
+    - items:
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Local:
                       kind:
-                        Literal:
+                        Init:
                           kind:
-                            String: "\"Arya\""
+                            Literal:
+                              kind:
+                                String: "\"Arya\""
+                              span:
+                                start: 31
+                                end: 37
                           span:
                             start: 31
                             end: 37
-                      span:
-                        start: 31
-                        end: 37
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: String
+                      name:
+                        name: name
+                        span:
+                          start: 24
+                          end: 28
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: String
-                  name:
-                    name: name
-                    span:
-                      start: 24
-                      end: 28
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: String
+                      span:
+                        start: 24
+                        end: 28
                   span:
                     start: 24
                     end: 28
-              span:
-                start: 24
-                end: 28
-            - kind:
-                Local:
-                  kind:
-                    Init:
+                - kind:
+                    Local:
                       kind:
-                        Literal:
+                        Init:
                           kind:
-                            Integer:
-                              Unsigned:
-                                - 100
-                                - Uint64
+                            Literal:
+                              kind:
+                                Integer:
+                                  Unsigned:
+                                    - 100
+                                    - Uint64
+                              span:
+                                start: 53
+                                end: 56
                           span:
                             start: 53
                             end: 56
-                      span:
-                        start: 53
-                        end: 56
+                          ty:
+                            UserDefined:
+                              module: "std::prelude"
+                              name: Uint64
+                      name:
+                        name: gold
+                        span:
+                          start: 46
+                          end: 50
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: Uint64
-                  name:
-                    name: gold
-                    span:
-                      start: 46
-                      end: 50
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: Uint64
+                      span:
+                        start: 46
+                        end: 50
                   span:
                     start: 46
                     end: 50
-              span:
-                start: 46
-                end: 50
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: print
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 62
+                                        end: 65
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 67
+                                        end: 69
+                                  - ident:
+                                      name: print
+                                      span:
+                                        start: 71
+                                        end: 76
+                                span:
+                                  start: 62
+                                  end: 76
+                            span:
+                              start: 62
+                              end: 76
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\"Hello, \""
+                                  span:
+                                    start: 77
+                                    end: 86
                               span:
-                                start: 62
-                                end: 67
-                        span:
-                          start: 62
-                          end: 67
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\"Hello, \""
-                              span:
-                                start: 68
-                                end: 77
-                          span:
-                            start: 68
-                            end: 77
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 77
+                                end: 86
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 62
+                        end: 76
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 62
-                    end: 67
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 62
-                end: 67
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: print
-                              span:
-                                start: 83
-                                end: 88
-                        span:
-                          start: 83
-                          end: 88
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Variable:
-                              name:
-                                name: name
+                    end: 76
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 92
+                                        end: 95
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 97
+                                        end: 99
+                                  - ident:
+                                      name: print
+                                      span:
+                                        start: 101
+                                        end: 106
                                 span:
-                                  start: 89
-                                  end: 93
-                          span:
-                            start: 89
-                            end: 93
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
-                  span:
-                    start: 83
-                    end: 88
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 83
-                end: 88
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
-                              span:
-                                start: 99
-                                end: 106
-                        span:
-                          start: 99
-                          end: 106
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\".\""
+                                  start: 92
+                                  end: 106
+                            span:
+                              start: 92
+                              end: 106
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Variable:
+                                  segments:
+                                    - ident:
+                                        name: name
+                                        span:
+                                          start: 107
+                                          end: 111
+                                  span:
+                                    start: 107
+                                    end: 111
                               span:
                                 start: 107
-                                end: 110
-                          span:
-                            start: 107
-                            end: 110
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                end: 111
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 92
+                        end: 106
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
-                    start: 99
+                    start: 92
                     end: 106
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 99
-                end: 106
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: print
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 117
+                                        end: 120
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 122
+                                        end: 124
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 126
+                                        end: 133
+                                span:
+                                  start: 117
+                                  end: 133
+                            span:
+                              start: 117
+                              end: 133
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\".\""
+                                  span:
+                                    start: 134
+                                    end: 137
                               span:
-                                start: 117
-                                end: 122
-                        span:
-                          start: 117
-                          end: 122
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\"You currently have \""
-                              span:
-                                start: 123
-                                end: 144
-                          span:
-                            start: 123
-                            end: 144
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 134
+                                end: 137
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 117
+                        end: 133
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
                     start: 117
-                    end: 122
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 117
-                end: 122
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: print
-                              span:
-                                start: 150
-                                end: 155
-                        span:
-                          start: 150
-                          end: 155
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Call:
-                              fun:
-                                kind:
-                                  Variable:
-                                    name:
-                                      name: int_to_string
+                    end: 133
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
                                       span:
-                                        start: 156
-                                        end: 169
+                                        start: 144
+                                        end: 147
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 149
+                                        end: 151
+                                  - ident:
+                                      name: print
+                                      span:
+                                        start: 153
+                                        end: 158
                                 span:
-                                  start: 156
-                                  end: 169
-                                ty:
-                                  UserDefined:
-                                    module: "?"
-                                    name: "?"
-                              args:
-                                - kind:
-                                    Variable:
-                                      name:
-                                        name: gold
-                                        span:
-                                          start: 170
-                                          end: 174
+                                  start: 144
+                                  end: 158
+                            span:
+                              start: 144
+                              end: 158
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\"You currently have \""
                                   span:
-                                    start: 170
-                                    end: 174
-                                  ty:
-                                    UserDefined:
-                                      module: "std::prelude"
-                                      name: Uint64
-                          span:
-                            start: 156
-                            end: 169
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
-                  span:
-                    start: 150
-                    end: 155
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 150
-                end: 155
-            - kind:
-                Expr:
-                  kind:
-                    Call:
-                      fun:
-                        kind:
-                          Variable:
-                            name:
-                              name: println
+                                    start: 159
+                                    end: 180
                               span:
-                                start: 181
-                                end: 188
-                        span:
-                          start: 181
-                          end: 188
-                        ty:
-                          UserDefined:
-                            module: "?"
-                            name: "?"
-                      args:
-                        - kind:
-                            Literal:
-                              kind:
-                                String: "\" gold at your disposal.\""
-                              span:
-                                start: 189
-                                end: 214
-                          span:
-                            start: 189
-                            end: 214
-                          ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: String
+                                start: 159
+                                end: 180
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 144
+                        end: 158
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
                   span:
-                    start: 181
-                    end: 188
-                  ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: ()
-              span:
-                start: 181
-                end: 188
-      name:
-        name: main
-        span:
-          start: 7
-          end: 11
+                    start: 144
+                    end: 158
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 186
+                                        end: 189
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 191
+                                        end: 193
+                                  - ident:
+                                      name: print
+                                      span:
+                                        start: 195
+                                        end: 200
+                                span:
+                                  start: 186
+                                  end: 200
+                            span:
+                              start: 186
+                              end: 200
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Call:
+                                  fun:
+                                    kind:
+                                      Variable:
+                                        segments:
+                                          - ident:
+                                              name: std
+                                              span:
+                                                start: 201
+                                                end: 204
+                                          - ident:
+                                              name: int
+                                              span:
+                                                start: 206
+                                                end: 209
+                                          - ident:
+                                              name: int_to_string
+                                              span:
+                                                start: 211
+                                                end: 224
+                                        span:
+                                          start: 201
+                                          end: 224
+                                    span:
+                                      start: 201
+                                      end: 224
+                                    ty:
+                                      UserDefined:
+                                        module: "?"
+                                        name: "?"
+                                  args:
+                                    - kind:
+                                        Variable:
+                                          segments:
+                                            - ident:
+                                                name: gold
+                                                span:
+                                                  start: 225
+                                                  end: 229
+                                          span:
+                                            start: 225
+                                            end: 229
+                                      span:
+                                        start: 225
+                                        end: 229
+                                      ty:
+                                        UserDefined:
+                                          module: "std::prelude"
+                                          name: Uint64
+                              span:
+                                start: 201
+                                end: 224
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 186
+                        end: 200
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
+                  span:
+                    start: 186
+                    end: 200
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 236
+                                        end: 239
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 241
+                                        end: 243
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 245
+                                        end: 252
+                                span:
+                                  start: 236
+                                  end: 252
+                            span:
+                              start: 236
+                              end: 252
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Literal:
+                                  kind:
+                                    String: "\" gold at your disposal.\""
+                                  span:
+                                    start: 253
+                                    end: 278
+                              span:
+                                start: 253
+                                end: 278
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 236
+                        end: 252
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
+                  span:
+                    start: 236
+                    end: 252
+              path:
+                segments:
+                  - ident:
+                      name: main
+                      span:
+                        start: 7
+                        end: 11
+                span:
+                  start: 7
+                  end: 11
+          name:
+            name: main
+            span:
+              start: 7
+              end: 11
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@struct_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@struct_decls.crane.snap
@@ -1,42 +1,43 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/struct_decls.crane
 ---
 Ok:
-  items:
-    - kind:
-        Struct:
-          Struct:
-            - name:
-                name: x
-                span:
-                  start: 19
-                  end: 20
-              ty:
-                name: Uint64
-                span:
-                  start: 22
-                  end: 28
-              span:
-                start: 19
-                end: 20
-            - name:
-                name: y
-                span:
-                  start: 34
-                  end: 35
-              ty:
-                name: Uint64
-                span:
-                  start: 37
-                  end: 43
-              span:
-                start: 34
-                end: 35
-      name:
-        name: Point
-        span:
-          start: 7
-          end: 12
+  modules:
+    - items:
+        - kind:
+            Struct:
+              Struct:
+                - name:
+                    name: x
+                    span:
+                      start: 19
+                      end: 20
+                  ty:
+                    name: Uint64
+                    span:
+                      start: 22
+                      end: 28
+                  span:
+                    start: 19
+                    end: 20
+                - name:
+                    name: y
+                    span:
+                      start: 34
+                      end: 35
+                  ty:
+                    name: Uint64
+                    span:
+                      start: 37
+                      end: 43
+                  span:
+                    start: 34
+                    end: 35
+          name:
+            name: Point
+            span:
+              start: 7
+              end: 12
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@union_decls.crane.snap
@@ -1,34 +1,35 @@
 ---
 source: crates/crane/src/typer.rs
-expression: typer.type_check_module(module)
+expression: typer.type_check_package(package)
 input_file: crates/crane/src/snapshot_inputs/union_decls.crane
 ---
 Ok:
-  items:
-    - kind:
-        Union:
-          variants:
-            - name:
-                name: "True"
-                span:
-                  start: 17
-                  end: 21
-              data: Unit
-              span:
-                start: 17
-                end: 21
-            - name:
-                name: "False"
-                span:
-                  start: 27
-                  end: 32
-              data: Unit
-              span:
-                start: 27
-                end: 32
-      name:
-        name: Bool
-        span:
-          start: 6
-          end: 10
+  modules:
+    - items:
+        - kind:
+            Union:
+              variants:
+                - name:
+                    name: "True"
+                    span:
+                      start: 17
+                      end: 21
+                  data: Unit
+                  span:
+                    start: 17
+                    end: 21
+                - name:
+                    name: "False"
+                    span:
+                      start: 27
+                      end: 32
+                  data: Unit
+                  span:
+                    start: 27
+                    end: 32
+          name:
+            name: Bool
+            span:
+              start: 6
+              end: 10
 

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -549,11 +549,7 @@ impl Typer {
                     }),
                 }?;
 
-                let (callee_params, callee_return_ty) =
-                    self.module_functions.get(callee).ok_or_else(|| TypeError {
-                        kind: TypeErrorKind::UnknownFunction(callee.clone()),
-                        span: callee.span,
-                    })?;
+                let (callee_params, callee_return_ty) = self.ensure_function_exists(callee)?;
 
                 let caller_args = args
                     .into_iter()

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -551,7 +551,7 @@ impl Typer {
 
                 let (callee_params, callee_return_ty) =
                     self.module_functions.get(callee).ok_or_else(|| TypeError {
-                        kind: TypeErrorKind::Error(format!("Function `{callee}` not found.",)),
+                        kind: TypeErrorKind::UnknownFunction(callee.clone()),
                         span: callee.span,
                     })?;
 

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -325,7 +325,7 @@ impl Typer {
         Ok(())
     }
 
-    pub fn type_check_module(
+    fn type_check_module(
         &mut self,
         prefix: Option<&ThinVec<TyPathSegment>>,
         module: Module,
@@ -738,9 +738,13 @@ mod tests {
 
             let module = Module { items };
 
+            let package = Package {
+                modules: thin_vec![module],
+            };
+
             let mut typer = Typer::new();
 
-            insta::assert_yaml_snapshot!(typer.type_check_module(None, module));
+            insta::assert_yaml_snapshot!(typer.type_check_package(package));
         })
     }
 }

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -81,8 +81,27 @@ impl Typer {
 
         // HACK: Register the functions from `std`.
         self.register_function(
-            Ident {
-                name: "print".into(),
+            TyPath {
+                segments: thin_vec![
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "std".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "io".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "print".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    }
+                ],
                 span: DUMMY_SPAN,
             },
             thin_vec![TyFnParam {
@@ -96,8 +115,27 @@ impl Typer {
             unit_ty.clone(),
         );
         self.register_function(
-            Ident {
-                name: "println".into(),
+            TyPath {
+                segments: thin_vec![
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "std".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "io".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "println".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    }
+                ],
                 span: DUMMY_SPAN,
             },
             thin_vec![TyFnParam {
@@ -111,8 +149,27 @@ impl Typer {
             unit_ty.clone(),
         );
         self.register_function(
-            Ident {
-                name: "int_add".into(),
+            TyPath {
+                segments: thin_vec![
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "std".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "int".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "int_add".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    }
+                ],
                 span: DUMMY_SPAN,
             },
             thin_vec![
@@ -136,8 +193,27 @@ impl Typer {
             uint64_ty.clone(),
         );
         self.register_function(
-            Ident {
-                name: "int_to_string".into(),
+            TyPath {
+                segments: thin_vec![
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "std".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "int".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    },
+                    TyPathSegment {
+                        ident: Ident {
+                            name: "int_to_string".into(),
+                            span: DUMMY_SPAN,
+                        }
+                    }
+                ],
                 span: DUMMY_SPAN,
             },
             thin_vec![TyFnParam {
@@ -168,7 +244,16 @@ impl Typer {
                         })
                         .unwrap_or(unit_ty.clone());
 
-                    self.register_function(item.name.clone(), params.clone(), return_ty);
+                    self.register_function(
+                        TyPath {
+                            segments: thin_vec![TyPathSegment {
+                                ident: item.name.clone()
+                            }],
+                            span: item.name.span,
+                        },
+                        params.clone(),
+                        return_ty,
+                    );
                 }
                 ItemKind::Struct(_) => {}
                 ItemKind::Union(_) => {}
@@ -191,16 +276,13 @@ impl Typer {
         Ok(TyModule { items: typed_items })
     }
 
-    fn register_function(&mut self, name: Ident, params: ThinVec<TyFnParam>, return_ty: Arc<Type>) {
-        self.module_functions.insert(
-            TyPath {
-                segments: thin_vec![TyPathSegment {
-                    ident: name.clone()
-                }],
-                span: name.span,
-            },
-            (params, return_ty),
-        );
+    fn register_function(
+        &mut self,
+        path: TyPath,
+        params: ThinVec<TyFnParam>,
+        return_ty: Arc<Type>,
+    ) {
+        self.module_functions.insert(path, (params, return_ty));
     }
 
     fn ensure_function_exists(

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Ident, Span};
+use crate::ast::{Span, TyPath};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TypeError {
@@ -10,6 +10,6 @@ pub struct TypeError {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TypeErrorKind {
-    UnknownFunction { name: Ident },
+    UnknownFunction(TyPath),
     Error(String),
 }

--- a/examples/functions.crane
+++ b/examples/functions.crane
@@ -7,9 +7,9 @@ pub fn main() {
 }
 
 fn say_hello() {
-    println("Hello")
+    std::io::println("Hello")
 }
 
 fn say_goodbye() {
-    println("Goodbye")
+    std::io::println("Goodbye")
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -26,6 +26,8 @@ mod foo {
 pub fn main() {
     let twenty_three = 23
 
+    foo::do_foo()
+
     std::io::print("twenty_three = ")
     std::io::println(std::int::int_to_string(twenty_three))
     std::io::println(" ")

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -13,12 +13,12 @@ union Bool {
 
 mod foo {
     fn do_foo() {
-        println("Hello from `foo`")
+        std::io::println("Hello from `foo`")
     }
 
     mod bar {
         fn do_bar() {
-            println("Hello from `bar`")
+            std::io::println("Hello from `bar`")
         }
     }
 }
@@ -26,40 +26,40 @@ mod foo {
 pub fn main() {
     let twenty_three = 23
 
-    print("twenty_three = ")
-    println(int_to_string(twenty_three))
-    println(" ")
+    std::io::print("twenty_three = ")
+    std::io::println(std::int::int_to_string(twenty_three))
+    std::io::println(" ")
 
     let greeting = "Hey"
 
-    print("greeting = ")
-    println(greeting)
-    println(" ")
+    std::io::print("greeting = ")
+    std::io::println(greeting)
+    std::io::println(" ")
 
     greet("world")
     greet("trees")
     greet("everyone")
     std::io::println("")
 
-    print("This value is always ")
-    println(int_to_string(always_3()))
-    println("")
+    std::io::print("This value is always ")
+    std::io::println(std::int::int_to_string(always_3()))
+    std::io::println("")
 
     let also_always_3 = always_3()
-    print("This value is also always ")
-    println(int_to_string(also_always_3))
-    println("")
+    std::io::print("This value is also always ")
+    std::io::println(std::int::int_to_string(also_always_3))
+    std::io::println("")
 
-    let ten = int_add(also_always_3, 7)
-    print("This value should be 10: ")
-    println(int_to_string(ten))
-    println("")
+    let ten = std::int::int_add(also_always_3, 7)
+    std::io::print("This value should be 10: ")
+    std::io::println(std::int::int_to_string(ten))
+    std::io::println("")
 
     add_and_print(1, 1)
     add_and_print(2, 2)
     add_and_print(3, 3)
-    print("7 + 5 = ")
-    println(int_to_string(add_5(7)))
+    std::io::print("7 + 5 = ")
+    std::io::println(std::int::int_to_string(add_5(7)))
 }
 
 fn always_3() -> Uint64 {
@@ -67,26 +67,26 @@ fn always_3() -> Uint64 {
 }
 
 fn add_5(value: Uint64) -> Uint64 {
-    int_add(value, 5)
+    std::int::int_add(value, 5)
 }
 
 fn greet(name: String) {
     join("Hello", name)
-    print("!")
-    println("")
+    std::io::print("!")
+    std::io::println("")
 }
 
 fn join(a: String, b: String) {
-    print(a)
-    print(", ")
-    print(b)
+    std::io::print(a)
+    std::io::print(", ")
+    std::io::print(b)
 }
 
 fn add_and_print(a: Uint64, b: Uint64) {
-    print(int_to_string(a))
-    print(" + ")
-    print(int_to_string(b))
-    print(" = ")
-    print(int_to_string(int_add(a, b)))
-    println("")
+    std::io::print(std::int::int_to_string(a))
+    std::io::print(" + ")
+    std::io::print(std::int::int_to_string(b))
+    std::io::print(" = ")
+    std::io::print(std::int::int_to_string(std::int::int_add(a, b)))
+    std::io::println("")
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -11,22 +11,11 @@ union Bool {
     False,
 }
 
-mod foo {
-    fn do_foo() {
-        std::io::println("Hello from `foo`")
-    }
-
-    mod bar {
-        fn do_bar() {
-            std::io::println("Hello from `bar`")
-        }
-    }
-}
-
 pub fn main() {
     let twenty_three = 23
 
     foo::do_foo()
+    foo::bar::do_bar()
 
     std::io::print("twenty_three = ")
     std::io::println(std::int::int_to_string(twenty_three))
@@ -91,4 +80,16 @@ fn add_and_print(a: Uint64, b: Uint64) {
     std::io::print(" = ")
     std::io::print(std::int::int_to_string(std::int::int_add(a, b)))
     std::io::println("")
+}
+
+mod foo {
+    fn do_foo() {
+        std::io::println("Hello from `foo`")
+    }
+
+    mod bar {
+        fn do_bar() {
+            std::io::println("Hello from `bar`")
+        }
+    }
 }


### PR DESCRIPTION
This PR updates the typed AST to use `TyPath`s instead of `Ident`s for variables.

This allows us to refer to functions defined in other (inline) modules.

However, it does come at the cost of having to prefix all of the standard library function calls with the appropriate path prefix. This is just a temporary thing, as once `use` items are implemented it will be possible to bring these functions into scope.

The code powering this is... rough, to put it nicely. Building up and keeping track of absolute paths to items is rather hard to do in an ad-hoc way. I suspect we'll need to redo this very soon.