### PR TITLE
Provide suggestions for similarly-named functions when one is not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,11 @@ dependencies = [
  "clap",
  "inkwell",
  "insta",
+ "itertools",
  "logos",
  "serde",
  "smol_str",
+ "strsim",
  "thin-vec",
  "thiserror",
  "tracing",
@@ -322,6 +324,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/crates/crane/Cargo.toml
+++ b/crates/crane/Cargo.toml
@@ -9,9 +9,11 @@ edition = "2021"
 ariadne = "0.3.0"
 clap = { version = "4.3.3", features = ["derive"] }
 inkwell = { version = "0.2.0", features = ["llvm16-0"] }
+itertools = "0.10.5"
 logos = "0.13.0"
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 smol_str = { version = "0.2.0", features = ["serde"] }
+strsim = "0.10.0"
 thin-vec = { version = "0.2.12", features = ["serde"] }
 thiserror = "1.0.40"
 tracing = "0.1.37"

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -109,7 +109,14 @@ impl Typer {
         }
 
         Err(TypeError {
-            kind: TypeErrorKind::UnknownFunction(path.clone()),
+            kind: TypeErrorKind::UnknownFunction {
+                path: path.clone(),
+                options: self
+                    .module_functions
+                    .keys()
+                    .cloned()
+                    .collect::<ThinVec<_>>(),
+            },
             span: path.span,
         })
     }

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use thin_vec::ThinVec;
 
 use crate::ast::{Span, TyPath};
 
@@ -10,6 +11,9 @@ pub struct TypeError {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TypeErrorKind {
-    UnknownFunction(TyPath),
+    UnknownFunction {
+        path: TyPath,
+        options: ThinVec<TyPath>,
+    },
     Error(String),
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -62,7 +62,7 @@ fn add_5(value: Uint64) -> Uint64 {
 }
 
 fn greet(name: String) {
-    join2("Hello", name)
+    join("Hello", name)
     std::io::print("!")
     std::io::println("")
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -62,7 +62,7 @@ fn add_5(value: Uint64) -> Uint64 {
 }
 
 fn greet(name: String) {
-    join("Hello", name)
+    join2("Hello", name)
     std::io::print("!")
     std::io::println("")
 }


### PR DESCRIPTION
This PR adds a suggestion to the type error when a function is not found for a function with a similar name.

<img width="1345" alt="Screenshot 2023-06-18 at 11 04 20 PM" src="https://github.com/crane-lang/crane/assets/1486634/b838af4f-6a80-464f-9261-8c2959feaad7">

