### PR TITLE
Bring functions into scope with `use`

### DIFF
--- a/crates/crane/src/snapshot_inputs/function_return_types.crane
+++ b/crates/crane/src/snapshot_inputs/function_return_types.crane
@@ -1,7 +1,11 @@
+use std::int::int_add
+use std::int::int_to_string
+use std::io::println
+
 fn main() {
-    std::io::println(std::int::int_to_string(add_10(5)))
+    println(int_to_string(add_10(5)))
 }
 
 fn add_10(n: Uint64) -> Uint64 {
-    std::int::int_add(n, 10)
+    int_add(n, 10)
 }

--- a/crates/crane/src/snapshot_inputs/functions.crane
+++ b/crates/crane/src/snapshot_inputs/functions.crane
@@ -1,12 +1,14 @@
+use std::io::println
+
 pub fn main() {
     say_hello()
     say_goodbye()
 }
 
 fn say_hello() {
-    std::io::println("Hello")
+    println("Hello")
 }
 
 fn say_goodbye() {
-    std::io::println("Goodbye")
+    println("Goodbye")
 }

--- a/crates/crane/src/snapshot_inputs/hello_world.crane
+++ b/crates/crane/src/snapshot_inputs/hello_world.crane
@@ -1,6 +1,5 @@
-// TODO: Handle imports.
-// use std::io::println
+use std::io::println
 
 pub fn main() {
-    std::io::println("Hello, world!")
+    println("Hello, world!")
 }

--- a/crates/crane/src/snapshot_inputs/let_bindings.crane
+++ b/crates/crane/src/snapshot_inputs/let_bindings.crane
@@ -1,12 +1,16 @@
+use std::int::int_to_string
+use std::io::print
+use std::io::println
+
 pub fn main() {
     let name = "Arya"
     let gold = 100
 
-    std::io::print("Hello, ")
-    std::io::print(name)
-    std::io::println(".")
+    print("Hello, ")
+    print(name)
+    println(".")
 
-    std::io::print("You currently have ")
-    std::io::print(std::int::int_to_string(gold))
-    std::io::println(" gold at your disposal.")
+    print("You currently have ")
+    print(int_to_string(gold))
+    println(" gold at your disposal.")
 }

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@function_return_types.crane.snap
@@ -5,147 +5,111 @@ input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
 ---
 - Ok:
     kind: Ident
-    lexeme: fn
+    lexeme: use
     span:
       start: 0
-      end: 2
+      end: 3
 - Ok:
     kind: Ident
-    lexeme: main
+    lexeme: std
     span:
-      start: 3
+      start: 4
       end: 7
 - Ok:
-    kind: OpenParen
-    lexeme: (
+    kind: ColonColon
+    lexeme: "::"
     span:
       start: 7
-      end: 8
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 8
       end: 9
-- Ok:
-    kind: OpenBrace
-    lexeme: "{"
-    span:
-      start: 10
-      end: 11
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 16
-      end: 19
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 19
-      end: 21
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 21
-      end: 23
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 23
-      end: 25
-- Ok:
-    kind: Ident
-    lexeme: println
-    span:
-      start: 25
-      end: 32
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 32
-      end: 33
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 33
-      end: 36
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 36
-      end: 38
 - Ok:
     kind: Ident
     lexeme: int
     span:
-      start: 38
-      end: 41
+      start: 9
+      end: 12
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 41
-      end: 43
+      start: 12
+      end: 14
+- Ok:
+    kind: Ident
+    lexeme: int_add
+    span:
+      start: 14
+      end: 21
+- Ok:
+    kind: Ident
+    lexeme: use
+    span:
+      start: 22
+      end: 25
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 26
+      end: 29
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 29
+      end: 31
+- Ok:
+    kind: Ident
+    lexeme: int
+    span:
+      start: 31
+      end: 34
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 34
+      end: 36
 - Ok:
     kind: Ident
     lexeme: int_to_string
     span:
-      start: 43
-      end: 56
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 56
-      end: 57
+      start: 36
+      end: 49
 - Ok:
     kind: Ident
-    lexeme: add_10
+    lexeme: use
+    span:
+      start: 50
+      end: 53
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 54
+      end: 57
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
     span:
       start: 57
+      end: 59
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 59
+      end: 61
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 61
       end: 63
 - Ok:
-    kind: OpenParen
-    lexeme: (
+    kind: Ident
+    lexeme: println
     span:
       start: 63
-      end: 64
-- Ok:
-    kind: Integer
-    lexeme: "5"
-    span:
-      start: 64
-      end: 65
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 65
-      end: 66
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 66
-      end: 67
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 67
-      end: 68
-- Ok:
-    kind: CloseBrace
-    lexeme: "}"
-    span:
-      start: 69
       end: 70
 - Ok:
     kind: Ident
@@ -155,122 +119,194 @@ input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
       end: 74
 - Ok:
     kind: Ident
-    lexeme: add_10
+    lexeme: main
     span:
       start: 75
-      end: 81
+      end: 79
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 81
-      end: 82
-- Ok:
-    kind: Ident
-    lexeme: n
-    span:
-      start: 82
-      end: 83
-- Ok:
-    kind: Colon
-    lexeme: ":"
-    span:
-      start: 83
-      end: 84
-- Ok:
-    kind: Ident
-    lexeme: Uint64
-    span:
-      start: 85
-      end: 91
+      start: 79
+      end: 80
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 91
-      end: 92
-- Ok:
-    kind: RightArrow
-    lexeme: "->"
-    span:
-      start: 93
-      end: 95
-- Ok:
-    kind: Ident
-    lexeme: Uint64
-    span:
-      start: 96
-      end: 102
+      start: 80
+      end: 81
 - Ok:
     kind: OpenBrace
     lexeme: "{"
     span:
-      start: 103
-      end: 104
+      start: 82
+      end: 83
 - Ok:
     kind: Ident
-    lexeme: std
+    lexeme: println
     span:
-      start: 109
-      end: 112
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 112
-      end: 114
-- Ok:
-    kind: Ident
-    lexeme: int
-    span:
-      start: 114
-      end: 117
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 117
-      end: 119
-- Ok:
-    kind: Ident
-    lexeme: int_add
-    span:
-      start: 119
-      end: 126
+      start: 88
+      end: 95
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 126
-      end: 127
+      start: 95
+      end: 96
 - Ok:
     kind: Ident
-    lexeme: n
+    lexeme: int_to_string
     span:
-      start: 127
-      end: 128
+      start: 96
+      end: 109
 - Ok:
-    kind: Comma
-    lexeme: ","
+    kind: OpenParen
+    lexeme: (
     span:
-      start: 128
-      end: 129
+      start: 109
+      end: 110
+- Ok:
+    kind: Ident
+    lexeme: add_10
+    span:
+      start: 110
+      end: 116
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 116
+      end: 117
 - Ok:
     kind: Integer
-    lexeme: "10"
+    lexeme: "5"
     span:
-      start: 130
-      end: 132
+      start: 117
+      end: 118
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 132
-      end: 133
+      start: 118
+      end: 119
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 119
+      end: 120
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 120
+      end: 121
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
+      start: 122
+      end: 123
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 125
+      end: 127
+- Ok:
+    kind: Ident
+    lexeme: add_10
+    span:
+      start: 128
+      end: 134
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
       start: 134
       end: 135
+- Ok:
+    kind: Ident
+    lexeme: n
+    span:
+      start: 135
+      end: 136
+- Ok:
+    kind: Colon
+    lexeme: ":"
+    span:
+      start: 136
+      end: 137
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 138
+      end: 144
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 144
+      end: 145
+- Ok:
+    kind: RightArrow
+    lexeme: "->"
+    span:
+      start: 146
+      end: 148
+- Ok:
+    kind: Ident
+    lexeme: Uint64
+    span:
+      start: 149
+      end: 155
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 156
+      end: 157
+- Ok:
+    kind: Ident
+    lexeme: int_add
+    span:
+      start: 162
+      end: 169
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 169
+      end: 170
+- Ok:
+    kind: Ident
+    lexeme: n
+    span:
+      start: 170
+      end: 171
+- Ok:
+    kind: Comma
+    lexeme: ","
+    span:
+      start: 171
+      end: 172
+- Ok:
+    kind: Integer
+    lexeme: "10"
+    span:
+      start: 173
+      end: 175
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 175
+      end: 176
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 177
+      end: 178
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@functions.crane.snap
@@ -5,248 +5,236 @@ input_file: crates/crane/src/snapshot_inputs/functions.crane
 ---
 - Ok:
     kind: Ident
-    lexeme: pub
+    lexeme: use
     span:
       start: 0
       end: 3
 - Ok:
     kind: Ident
-    lexeme: fn
+    lexeme: std
     span:
       start: 4
-      end: 6
+      end: 7
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 7
+      end: 9
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 9
+      end: 11
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 11
+      end: 13
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 13
+      end: 20
+- Ok:
+    kind: Ident
+    lexeme: pub
+    span:
+      start: 22
+      end: 25
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 26
+      end: 28
 - Ok:
     kind: Ident
     lexeme: main
     span:
-      start: 7
-      end: 11
+      start: 29
+      end: 33
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 11
-      end: 12
+      start: 33
+      end: 34
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 12
-      end: 13
+      start: 34
+      end: 35
 - Ok:
     kind: OpenBrace
     lexeme: "{"
     span:
-      start: 14
-      end: 15
+      start: 36
+      end: 37
 - Ok:
     kind: Ident
     lexeme: say_hello
     span:
-      start: 20
-      end: 29
+      start: 42
+      end: 51
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 29
-      end: 30
+      start: 51
+      end: 52
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 30
-      end: 31
+      start: 52
+      end: 53
 - Ok:
     kind: Ident
     lexeme: say_goodbye
     span:
-      start: 36
-      end: 47
+      start: 58
+      end: 69
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 47
-      end: 48
+      start: 69
+      end: 70
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 48
-      end: 49
+      start: 70
+      end: 71
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 50
-      end: 51
+      start: 72
+      end: 73
 - Ok:
     kind: Ident
     lexeme: fn
     span:
-      start: 53
-      end: 55
+      start: 75
+      end: 77
 - Ok:
     kind: Ident
     lexeme: say_hello
     span:
-      start: 56
-      end: 65
+      start: 78
+      end: 87
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 65
-      end: 66
+      start: 87
+      end: 88
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 66
-      end: 67
+      start: 88
+      end: 89
 - Ok:
     kind: OpenBrace
     lexeme: "{"
-    span:
-      start: 68
-      end: 69
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 74
-      end: 77
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 77
-      end: 79
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 79
-      end: 81
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 81
-      end: 83
-- Ok:
-    kind: Ident
-    lexeme: println
-    span:
-      start: 83
-      end: 90
-- Ok:
-    kind: OpenParen
-    lexeme: (
     span:
       start: 90
       end: 91
 - Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 96
+      end: 103
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 103
+      end: 104
+- Ok:
     kind: String
     lexeme: "\"Hello\""
     span:
-      start: 91
-      end: 98
+      start: 104
+      end: 111
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 98
-      end: 99
+      start: 111
+      end: 112
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 100
-      end: 101
+      start: 113
+      end: 114
 - Ok:
     kind: Ident
     lexeme: fn
     span:
-      start: 103
-      end: 105
+      start: 116
+      end: 118
 - Ok:
     kind: Ident
     lexeme: say_goodbye
     span:
-      start: 106
-      end: 117
+      start: 119
+      end: 130
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 117
-      end: 118
+      start: 130
+      end: 131
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 118
-      end: 119
+      start: 131
+      end: 132
 - Ok:
     kind: OpenBrace
     lexeme: "{"
     span:
-      start: 120
-      end: 121
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 126
-      end: 129
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 129
-      end: 131
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 131
-      end: 133
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
       start: 133
-      end: 135
+      end: 134
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 135
-      end: 142
+      start: 139
+      end: 146
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 142
-      end: 143
+      start: 146
+      end: 147
 - Ok:
     kind: String
     lexeme: "\"Goodbye\""
     span:
-      start: 143
-      end: 152
+      start: 147
+      end: 156
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 152
-      end: 153
+      start: 156
+      end: 157
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 154
-      end: 155
+      start: 158
+      end: 159
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@hello_world.crane.snap
@@ -4,105 +4,105 @@ expression: "lexer.into_iter().collect::<Vec<_>>()"
 input_file: crates/crane/src/snapshot_inputs/hello_world.crane
 ---
 - Ok:
-    kind: Comment
-    lexeme: "// TODO: Handle imports."
+    kind: Ident
+    lexeme: use
     span:
       start: 0
-      end: 24
-- Ok:
-    kind: Comment
-    lexeme: "// use std::io::println"
-    span:
-      start: 25
-      end: 48
-- Ok:
-    kind: Ident
-    lexeme: pub
-    span:
-      start: 50
-      end: 53
-- Ok:
-    kind: Ident
-    lexeme: fn
-    span:
-      start: 54
-      end: 56
-- Ok:
-    kind: Ident
-    lexeme: main
-    span:
-      start: 57
-      end: 61
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 61
-      end: 62
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 62
-      end: 63
-- Ok:
-    kind: OpenBrace
-    lexeme: "{"
-    span:
-      start: 64
-      end: 65
+      end: 3
 - Ok:
     kind: Ident
     lexeme: std
     span:
-      start: 70
-      end: 73
+      start: 4
+      end: 7
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 73
-      end: 75
+      start: 7
+      end: 9
 - Ok:
     kind: Ident
     lexeme: io
     span:
-      start: 75
-      end: 77
+      start: 9
+      end: 11
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 77
-      end: 79
+      start: 11
+      end: 13
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 79
-      end: 86
+      start: 13
+      end: 20
+- Ok:
+    kind: Ident
+    lexeme: pub
+    span:
+      start: 22
+      end: 25
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 26
+      end: 28
+- Ok:
+    kind: Ident
+    lexeme: main
+    span:
+      start: 29
+      end: 33
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 86
-      end: 87
-- Ok:
-    kind: String
-    lexeme: "\"Hello, world!\""
-    span:
-      start: 87
-      end: 102
+      start: 33
+      end: 34
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 102
-      end: 103
+      start: 34
+      end: 35
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 36
+      end: 37
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 42
+      end: 49
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 49
+      end: 50
+- Ok:
+    kind: String
+    lexeme: "\"Hello, world!\""
+    span:
+      start: 50
+      end: 65
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 65
+      end: 66
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 104
-      end: 105
+      start: 67
+      end: 68
 

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@let_bindings.crane.snap
@@ -5,345 +5,297 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
 ---
 - Ok:
     kind: Ident
-    lexeme: pub
+    lexeme: use
     span:
       start: 0
       end: 3
 - Ok:
     kind: Ident
-    lexeme: fn
+    lexeme: std
     span:
       start: 4
-      end: 6
+      end: 7
 - Ok:
-    kind: Ident
-    lexeme: main
+    kind: ColonColon
+    lexeme: "::"
     span:
       start: 7
-      end: 11
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 11
-      end: 12
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 12
-      end: 13
-- Ok:
-    kind: OpenBrace
-    lexeme: "{"
-    span:
-      start: 14
-      end: 15
-- Ok:
-    kind: Ident
-    lexeme: let
-    span:
-      start: 20
-      end: 23
-- Ok:
-    kind: Ident
-    lexeme: name
-    span:
-      start: 24
-      end: 28
-- Ok:
-    kind: Equal
-    lexeme: "="
-    span:
-      start: 29
-      end: 30
-- Ok:
-    kind: String
-    lexeme: "\"Arya\""
-    span:
-      start: 31
-      end: 37
-- Ok:
-    kind: Ident
-    lexeme: let
-    span:
-      start: 42
-      end: 45
-- Ok:
-    kind: Ident
-    lexeme: gold
-    span:
-      start: 46
-      end: 50
-- Ok:
-    kind: Equal
-    lexeme: "="
-    span:
-      start: 51
-      end: 52
-- Ok:
-    kind: Integer
-    lexeme: "100"
-    span:
-      start: 53
-      end: 56
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 62
-      end: 65
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 65
-      end: 67
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 67
-      end: 69
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 69
-      end: 71
-- Ok:
-    kind: Ident
-    lexeme: print
-    span:
-      start: 71
-      end: 76
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 76
-      end: 77
-- Ok:
-    kind: String
-    lexeme: "\"Hello, \""
-    span:
-      start: 77
-      end: 86
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 86
-      end: 87
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 92
-      end: 95
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 95
-      end: 97
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 97
-      end: 99
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 99
-      end: 101
-- Ok:
-    kind: Ident
-    lexeme: print
-    span:
-      start: 101
-      end: 106
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 106
-      end: 107
-- Ok:
-    kind: Ident
-    lexeme: name
-    span:
-      start: 107
-      end: 111
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 111
-      end: 112
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 117
-      end: 120
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 120
-      end: 122
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 122
-      end: 124
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 124
-      end: 126
-- Ok:
-    kind: Ident
-    lexeme: println
-    span:
-      start: 126
-      end: 133
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 133
-      end: 134
-- Ok:
-    kind: String
-    lexeme: "\".\""
-    span:
-      start: 134
-      end: 137
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 137
-      end: 138
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 144
-      end: 147
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 147
-      end: 149
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 149
-      end: 151
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 151
-      end: 153
-- Ok:
-    kind: Ident
-    lexeme: print
-    span:
-      start: 153
-      end: 158
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 158
-      end: 159
-- Ok:
-    kind: String
-    lexeme: "\"You currently have \""
-    span:
-      start: 159
-      end: 180
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 180
-      end: 181
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 186
-      end: 189
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 189
-      end: 191
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 191
-      end: 193
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 193
-      end: 195
-- Ok:
-    kind: Ident
-    lexeme: print
-    span:
-      start: 195
-      end: 200
-- Ok:
-    kind: OpenParen
-    lexeme: (
-    span:
-      start: 200
-      end: 201
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 201
-      end: 204
-- Ok:
-    kind: ColonColon
-    lexeme: "::"
-    span:
-      start: 204
-      end: 206
+      end: 9
 - Ok:
     kind: Ident
     lexeme: int
     span:
-      start: 206
-      end: 209
+      start: 9
+      end: 12
 - Ok:
     kind: ColonColon
     lexeme: "::"
     span:
-      start: 209
-      end: 211
+      start: 12
+      end: 14
 - Ok:
     kind: Ident
     lexeme: int_to_string
     span:
-      start: 211
+      start: 14
+      end: 27
+- Ok:
+    kind: Ident
+    lexeme: use
+    span:
+      start: 28
+      end: 31
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 32
+      end: 35
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 35
+      end: 37
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 37
+      end: 39
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 39
+      end: 41
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 41
+      end: 46
+- Ok:
+    kind: Ident
+    lexeme: use
+    span:
+      start: 47
+      end: 50
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 51
+      end: 54
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 54
+      end: 56
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 56
+      end: 58
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 58
+      end: 60
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 60
+      end: 67
+- Ok:
+    kind: Ident
+    lexeme: pub
+    span:
+      start: 69
+      end: 72
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 73
+      end: 75
+- Ok:
+    kind: Ident
+    lexeme: main
+    span:
+      start: 76
+      end: 80
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 80
+      end: 81
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 81
+      end: 82
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 83
+      end: 84
+- Ok:
+    kind: Ident
+    lexeme: let
+    span:
+      start: 89
+      end: 92
+- Ok:
+    kind: Ident
+    lexeme: name
+    span:
+      start: 93
+      end: 97
+- Ok:
+    kind: Equal
+    lexeme: "="
+    span:
+      start: 98
+      end: 99
+- Ok:
+    kind: String
+    lexeme: "\"Arya\""
+    span:
+      start: 100
+      end: 106
+- Ok:
+    kind: Ident
+    lexeme: let
+    span:
+      start: 111
+      end: 114
+- Ok:
+    kind: Ident
+    lexeme: gold
+    span:
+      start: 115
+      end: 119
+- Ok:
+    kind: Equal
+    lexeme: "="
+    span:
+      start: 120
+      end: 121
+- Ok:
+    kind: Integer
+    lexeme: "100"
+    span:
+      start: 122
+      end: 125
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 131
+      end: 136
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 136
+      end: 137
+- Ok:
+    kind: String
+    lexeme: "\"Hello, \""
+    span:
+      start: 137
+      end: 146
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 146
+      end: 147
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 152
+      end: 157
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 157
+      end: 158
+- Ok:
+    kind: Ident
+    lexeme: name
+    span:
+      start: 158
+      end: 162
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 162
+      end: 163
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 168
+      end: 175
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 175
+      end: 176
+- Ok:
+    kind: String
+    lexeme: "\".\""
+    span:
+      start: 176
+      end: 179
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 179
+      end: 180
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 186
+      end: 191
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 191
+      end: 192
+- Ok:
+    kind: String
+    lexeme: "\"You currently have \""
+    span:
+      start: 192
+      end: 213
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 213
+      end: 214
+- Ok:
+    kind: Ident
+    lexeme: print
+    span:
+      start: 219
       end: 224
 - Ok:
     kind: OpenParen
@@ -353,74 +305,62 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
       end: 225
 - Ok:
     kind: Ident
-    lexeme: gold
+    lexeme: int_to_string
     span:
       start: 225
-      end: 229
+      end: 238
 - Ok:
-    kind: CloseParen
-    lexeme: )
+    kind: OpenParen
+    lexeme: (
     span:
-      start: 229
-      end: 230
-- Ok:
-    kind: CloseParen
-    lexeme: )
-    span:
-      start: 230
-      end: 231
-- Ok:
-    kind: Ident
-    lexeme: std
-    span:
-      start: 236
+      start: 238
       end: 239
 - Ok:
-    kind: ColonColon
-    lexeme: "::"
+    kind: Ident
+    lexeme: gold
     span:
       start: 239
-      end: 241
-- Ok:
-    kind: Ident
-    lexeme: io
-    span:
-      start: 241
       end: 243
 - Ok:
-    kind: ColonColon
-    lexeme: "::"
+    kind: CloseParen
+    lexeme: )
     span:
       start: 243
+      end: 244
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 244
       end: 245
 - Ok:
     kind: Ident
     lexeme: println
     span:
-      start: 245
-      end: 252
+      start: 250
+      end: 257
 - Ok:
     kind: OpenParen
     lexeme: (
     span:
-      start: 252
-      end: 253
+      start: 257
+      end: 258
 - Ok:
     kind: String
     lexeme: "\" gold at your disposal.\""
     span:
-      start: 253
-      end: 278
+      start: 258
+      end: 283
 - Ok:
     kind: CloseParen
     lexeme: )
     span:
-      start: 278
-      end: 279
+      start: 283
+      end: 284
 - Ok:
     kind: CloseBrace
     lexeme: "}"
     span:
-      start: 280
-      end: 281
+      start: 285
+      end: 286
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
@@ -5,6 +5,90 @@ input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
 ---
 Ok:
   - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 4
+                  end: 7
+            - ident:
+                name: int
+                span:
+                  start: 9
+                  end: 12
+            - ident:
+                name: int_add
+                span:
+                  start: 14
+                  end: 21
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 26
+                  end: 29
+            - ident:
+                name: int
+                span:
+                  start: 31
+                  end: 34
+            - ident:
+                name: int_to_string
+                span:
+                  start: 36
+                  end: 49
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 54
+                  end: 57
+            - ident:
+                name: io
+                span:
+                  start: 59
+                  end: 61
+            - ident:
+                name: println
+                span:
+                  start: 63
+                  end: 70
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
       Fn:
         params: []
         return_ty: ~
@@ -18,26 +102,16 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 16
-                                  end: 19
-                            - ident:
-                                name: io
-                                span:
-                                  start: 21
-                                  end: 23
-                            - ident:
                                 name: println
                                 span:
-                                  start: 25
-                                  end: 32
+                                  start: 88
+                                  end: 95
                           span:
-                            start: 16
-                            end: 32
+                            start: 88
+                            end: 95
                       span:
-                        start: 16
-                        end: 32
+                        start: 88
+                        end: 95
                     args:
                       - kind:
                           Call:
@@ -46,26 +120,16 @@ Ok:
                                 Variable:
                                   segments:
                                     - ident:
-                                        name: std
-                                        span:
-                                          start: 33
-                                          end: 36
-                                    - ident:
-                                        name: int
-                                        span:
-                                          start: 38
-                                          end: 41
-                                    - ident:
                                         name: int_to_string
                                         span:
-                                          start: 43
-                                          end: 56
+                                          start: 96
+                                          end: 109
                                   span:
-                                    start: 33
-                                    end: 56
+                                    start: 96
+                                    end: 109
                               span:
-                                start: 33
-                                end: 56
+                                start: 96
+                                end: 109
                             args:
                               - kind:
                                   Call:
@@ -76,60 +140,60 @@ Ok:
                                             - ident:
                                                 name: add_10
                                                 span:
-                                                  start: 57
-                                                  end: 63
+                                                  start: 110
+                                                  end: 116
                                           span:
-                                            start: 57
-                                            end: 63
+                                            start: 110
+                                            end: 116
                                       span:
-                                        start: 57
-                                        end: 63
+                                        start: 110
+                                        end: 116
                                     args:
                                       - kind:
                                           Literal:
                                             kind: Integer
                                             value: "5"
                                         span:
-                                          start: 64
-                                          end: 65
+                                          start: 117
+                                          end: 118
                                 span:
-                                  start: 57
-                                  end: 63
+                                  start: 110
+                                  end: 116
                         span:
-                          start: 33
-                          end: 56
+                          start: 96
+                          end: 109
                 span:
-                  start: 16
-                  end: 32
+                  start: 88
+                  end: 95
             span:
-              start: 16
-              end: 32
+              start: 88
+              end: 95
     name:
       name: main
       span:
-        start: 3
-        end: 7
+        start: 75
+        end: 79
   - kind:
       Fn:
         params:
           - name:
               name: n
               span:
-                start: 82
-                end: 83
+                start: 135
+                end: 136
             ty:
               name: Uint64
               span:
-                start: 85
-                end: 91
+                start: 138
+                end: 144
             span:
-              start: 82
-              end: 83
+              start: 135
+              end: 136
         return_ty:
           name: Uint64
           span:
-            start: 96
-            end: 102
+            start: 149
+            end: 155
         body:
           - kind:
               Expr:
@@ -140,26 +204,16 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 109
-                                  end: 112
-                            - ident:
-                                name: int
-                                span:
-                                  start: 114
-                                  end: 117
-                            - ident:
                                 name: int_add
                                 span:
-                                  start: 119
-                                  end: 126
+                                  start: 162
+                                  end: 169
                           span:
-                            start: 109
-                            end: 126
+                            start: 162
+                            end: 169
                       span:
-                        start: 109
-                        end: 126
+                        start: 162
+                        end: 169
                     args:
                       - kind:
                           Variable:
@@ -167,30 +221,30 @@ Ok:
                               - ident:
                                   name: n
                                   span:
-                                    start: 127
-                                    end: 128
+                                    start: 170
+                                    end: 171
                             span:
-                              start: 127
-                              end: 128
+                              start: 170
+                              end: 171
                         span:
-                          start: 127
-                          end: 128
+                          start: 170
+                          end: 171
                       - kind:
                           Literal:
                             kind: Integer
                             value: "10"
                         span:
-                          start: 130
-                          end: 132
+                          start: 173
+                          end: 175
                 span:
-                  start: 109
-                  end: 126
+                  start: 162
+                  end: 169
             span:
-              start: 109
-              end: 126
+              start: 162
+              end: 169
     name:
       name: add_10
       span:
-        start: 75
-        end: 81
+        start: 128
+        end: 134
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
@@ -5,6 +5,34 @@ input_file: crates/crane/src/snapshot_inputs/functions.crane
 ---
 Ok:
   - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 4
+                  end: 7
+            - ident:
+                name: io
+                span:
+                  start: 9
+                  end: 11
+            - ident:
+                name: println
+                span:
+                  start: 13
+                  end: 20
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
       Fn:
         params: []
         return_ty: ~
@@ -20,21 +48,21 @@ Ok:
                             - ident:
                                 name: say_hello
                                 span:
-                                  start: 20
-                                  end: 29
+                                  start: 42
+                                  end: 51
                           span:
-                            start: 20
-                            end: 29
+                            start: 42
+                            end: 51
                       span:
-                        start: 20
-                        end: 29
+                        start: 42
+                        end: 51
                     args: []
                 span:
-                  start: 20
-                  end: 29
+                  start: 42
+                  end: 51
             span:
-              start: 20
-              end: 29
+              start: 42
+              end: 51
           - kind:
               Expr:
                 kind:
@@ -46,26 +74,26 @@ Ok:
                             - ident:
                                 name: say_goodbye
                                 span:
-                                  start: 36
-                                  end: 47
+                                  start: 58
+                                  end: 69
                           span:
-                            start: 36
-                            end: 47
+                            start: 58
+                            end: 69
                       span:
-                        start: 36
-                        end: 47
+                        start: 58
+                        end: 69
                     args: []
                 span:
-                  start: 36
-                  end: 47
+                  start: 58
+                  end: 69
             span:
-              start: 36
-              end: 47
+              start: 58
+              end: 69
     name:
       name: main
       span:
-        start: 7
-        end: 11
+        start: 29
+        end: 33
   - kind:
       Fn:
         params: []
@@ -80,45 +108,35 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 74
-                                  end: 77
-                            - ident:
-                                name: io
-                                span:
-                                  start: 79
-                                  end: 81
-                            - ident:
                                 name: println
                                 span:
-                                  start: 83
-                                  end: 90
+                                  start: 96
+                                  end: 103
                           span:
-                            start: 74
-                            end: 90
+                            start: 96
+                            end: 103
                       span:
-                        start: 74
-                        end: 90
+                        start: 96
+                        end: 103
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello\""
                         span:
-                          start: 91
-                          end: 98
+                          start: 104
+                          end: 111
                 span:
-                  start: 74
-                  end: 90
+                  start: 96
+                  end: 103
             span:
-              start: 74
-              end: 90
+              start: 96
+              end: 103
     name:
       name: say_hello
       span:
-        start: 56
-        end: 65
+        start: 78
+        end: 87
   - kind:
       Fn:
         params: []
@@ -133,43 +151,33 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 126
-                                  end: 129
-                            - ident:
-                                name: io
-                                span:
-                                  start: 131
-                                  end: 133
-                            - ident:
                                 name: println
                                 span:
-                                  start: 135
-                                  end: 142
+                                  start: 139
+                                  end: 146
                           span:
-                            start: 126
-                            end: 142
+                            start: 139
+                            end: 146
                       span:
-                        start: 126
-                        end: 142
+                        start: 139
+                        end: 146
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Goodbye\""
                         span:
-                          start: 143
-                          end: 152
+                          start: 147
+                          end: 156
                 span:
-                  start: 126
-                  end: 142
+                  start: 139
+                  end: 146
             span:
-              start: 126
-              end: 142
+              start: 139
+              end: 146
     name:
       name: say_goodbye
       span:
-        start: 106
-        end: 117
+        start: 119
+        end: 130
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
@@ -5,6 +5,34 @@ input_file: crates/crane/src/snapshot_inputs/hello_world.crane
 ---
 Ok:
   - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 4
+                  end: 7
+            - ident:
+                name: io
+                span:
+                  start: 9
+                  end: 11
+            - ident:
+                name: println
+                span:
+                  start: 13
+                  end: 20
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
       Fn:
         params: []
         return_ty: ~
@@ -18,43 +46,33 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 70
-                                  end: 73
-                            - ident:
-                                name: io
-                                span:
-                                  start: 75
-                                  end: 77
-                            - ident:
                                 name: println
                                 span:
-                                  start: 79
-                                  end: 86
+                                  start: 42
+                                  end: 49
                           span:
-                            start: 70
-                            end: 86
+                            start: 42
+                            end: 49
                       span:
-                        start: 70
-                        end: 86
+                        start: 42
+                        end: 49
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello, world!\""
                         span:
-                          start: 87
-                          end: 102
+                          start: 50
+                          end: 65
                 span:
-                  start: 70
-                  end: 86
+                  start: 42
+                  end: 49
             span:
-              start: 70
-              end: 86
+              start: 42
+              end: 49
     name:
       name: main
       span:
-        start: 57
-        end: 61
+        start: 29
+        end: 33
 

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -5,6 +5,90 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
 ---
 Ok:
   - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 4
+                  end: 7
+            - ident:
+                name: int
+                span:
+                  start: 9
+                  end: 12
+            - ident:
+                name: int_to_string
+                span:
+                  start: 14
+                  end: 27
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 32
+                  end: 35
+            - ident:
+                name: io
+                span:
+                  start: 37
+                  end: 39
+            - ident:
+                name: print
+                span:
+                  start: 41
+                  end: 46
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 51
+                  end: 54
+            - ident:
+                name: io
+                span:
+                  start: 56
+                  end: 58
+            - ident:
+                name: println
+                span:
+                  start: 60
+                  end: 67
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
       Fn:
         params: []
         return_ty: ~
@@ -18,20 +102,20 @@ Ok:
                         kind: String
                         value: "\"Arya\""
                     span:
-                      start: 31
-                      end: 37
+                      start: 100
+                      end: 106
                 name:
                   name: name
                   span:
-                    start: 24
-                    end: 28
+                    start: 93
+                    end: 97
                 ty: ~
                 span:
-                  start: 24
-                  end: 28
+                  start: 93
+                  end: 97
             span:
-              start: 24
-              end: 28
+              start: 93
+              end: 97
           - kind:
               Local:
                 kind:
@@ -41,20 +125,20 @@ Ok:
                         kind: Integer
                         value: "100"
                     span:
-                      start: 53
-                      end: 56
+                      start: 122
+                      end: 125
                 name:
                   name: gold
                   span:
-                    start: 46
-                    end: 50
+                    start: 115
+                    end: 119
                 ty: ~
                 span:
-                  start: 46
-                  end: 50
+                  start: 115
+                  end: 119
             span:
-              start: 46
-              end: 50
+              start: 115
+              end: 119
           - kind:
               Expr:
                 kind:
@@ -64,40 +148,30 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 62
-                                  end: 65
-                            - ident:
-                                name: io
-                                span:
-                                  start: 67
-                                  end: 69
-                            - ident:
                                 name: print
                                 span:
-                                  start: 71
-                                  end: 76
+                                  start: 131
+                                  end: 136
                           span:
-                            start: 62
-                            end: 76
+                            start: 131
+                            end: 136
                       span:
-                        start: 62
-                        end: 76
+                        start: 131
+                        end: 136
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"Hello, \""
                         span:
-                          start: 77
-                          end: 86
+                          start: 137
+                          end: 146
                 span:
-                  start: 62
-                  end: 76
+                  start: 131
+                  end: 136
             span:
-              start: 62
-              end: 76
+              start: 131
+              end: 136
           - kind:
               Expr:
                 kind:
@@ -107,26 +181,16 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 92
-                                  end: 95
-                            - ident:
-                                name: io
-                                span:
-                                  start: 97
-                                  end: 99
-                            - ident:
                                 name: print
                                 span:
-                                  start: 101
-                                  end: 106
+                                  start: 152
+                                  end: 157
                           span:
-                            start: 92
-                            end: 106
+                            start: 152
+                            end: 157
                       span:
-                        start: 92
-                        end: 106
+                        start: 152
+                        end: 157
                     args:
                       - kind:
                           Variable:
@@ -134,20 +198,20 @@ Ok:
                               - ident:
                                   name: name
                                   span:
-                                    start: 107
-                                    end: 111
+                                    start: 158
+                                    end: 162
                             span:
-                              start: 107
-                              end: 111
+                              start: 158
+                              end: 162
                         span:
-                          start: 107
-                          end: 111
+                          start: 158
+                          end: 162
                 span:
-                  start: 92
-                  end: 106
+                  start: 152
+                  end: 157
             span:
-              start: 92
-              end: 106
+              start: 152
+              end: 157
           - kind:
               Expr:
                 kind:
@@ -157,40 +221,30 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 117
-                                  end: 120
-                            - ident:
-                                name: io
-                                span:
-                                  start: 122
-                                  end: 124
-                            - ident:
                                 name: println
                                 span:
-                                  start: 126
-                                  end: 133
+                                  start: 168
+                                  end: 175
                           span:
-                            start: 117
-                            end: 133
+                            start: 168
+                            end: 175
                       span:
-                        start: 117
-                        end: 133
+                        start: 168
+                        end: 175
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\".\""
                         span:
-                          start: 134
-                          end: 137
+                          start: 176
+                          end: 179
                 span:
-                  start: 117
-                  end: 133
+                  start: 168
+                  end: 175
             span:
-              start: 117
-              end: 133
+              start: 168
+              end: 175
           - kind:
               Expr:
                 kind:
@@ -200,40 +254,30 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 144
-                                  end: 147
-                            - ident:
-                                name: io
-                                span:
-                                  start: 149
-                                  end: 151
-                            - ident:
                                 name: print
                                 span:
-                                  start: 153
-                                  end: 158
+                                  start: 186
+                                  end: 191
                           span:
-                            start: 144
-                            end: 158
+                            start: 186
+                            end: 191
                       span:
-                        start: 144
-                        end: 158
+                        start: 186
+                        end: 191
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\"You currently have \""
                         span:
-                          start: 159
-                          end: 180
+                          start: 192
+                          end: 213
                 span:
-                  start: 144
-                  end: 158
+                  start: 186
+                  end: 191
             span:
-              start: 144
-              end: 158
+              start: 186
+              end: 191
           - kind:
               Expr:
                 kind:
@@ -243,26 +287,16 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 186
-                                  end: 189
-                            - ident:
-                                name: io
-                                span:
-                                  start: 191
-                                  end: 193
-                            - ident:
                                 name: print
                                 span:
-                                  start: 195
-                                  end: 200
+                                  start: 219
+                                  end: 224
                           span:
-                            start: 186
-                            end: 200
+                            start: 219
+                            end: 224
                       span:
-                        start: 186
-                        end: 200
+                        start: 219
+                        end: 224
                     args:
                       - kind:
                           Call:
@@ -271,26 +305,16 @@ Ok:
                                 Variable:
                                   segments:
                                     - ident:
-                                        name: std
-                                        span:
-                                          start: 201
-                                          end: 204
-                                    - ident:
-                                        name: int
-                                        span:
-                                          start: 206
-                                          end: 209
-                                    - ident:
                                         name: int_to_string
                                         span:
-                                          start: 211
-                                          end: 224
+                                          start: 225
+                                          end: 238
                                   span:
-                                    start: 201
-                                    end: 224
+                                    start: 225
+                                    end: 238
                               span:
-                                start: 201
-                                end: 224
+                                start: 225
+                                end: 238
                             args:
                               - kind:
                                   Variable:
@@ -298,23 +322,23 @@ Ok:
                                       - ident:
                                           name: gold
                                           span:
-                                            start: 225
-                                            end: 229
+                                            start: 239
+                                            end: 243
                                     span:
-                                      start: 225
-                                      end: 229
+                                      start: 239
+                                      end: 243
                                 span:
-                                  start: 225
-                                  end: 229
+                                  start: 239
+                                  end: 243
                         span:
-                          start: 201
-                          end: 224
+                          start: 225
+                          end: 238
                 span:
-                  start: 186
-                  end: 200
+                  start: 219
+                  end: 224
             span:
-              start: 186
-              end: 200
+              start: 219
+              end: 224
           - kind:
               Expr:
                 kind:
@@ -324,43 +348,33 @@ Ok:
                         Variable:
                           segments:
                             - ident:
-                                name: std
-                                span:
-                                  start: 236
-                                  end: 239
-                            - ident:
-                                name: io
-                                span:
-                                  start: 241
-                                  end: 243
-                            - ident:
                                 name: println
                                 span:
-                                  start: 245
-                                  end: 252
+                                  start: 250
+                                  end: 257
                           span:
-                            start: 236
-                            end: 252
+                            start: 250
+                            end: 257
                       span:
-                        start: 236
-                        end: 252
+                        start: 250
+                        end: 257
                     args:
                       - kind:
                           Literal:
                             kind: String
                             value: "\" gold at your disposal.\""
                         span:
-                          start: 253
-                          end: 278
+                          start: 258
+                          end: 283
                 span:
-                  start: 236
-                  end: 252
+                  start: 250
+                  end: 257
             span:
-              start: 236
-              end: 252
+              start: 250
+              end: 257
     name:
       name: main
       span:
-        start: 7
-        end: 11
+        start: 76
+        end: 80
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
@@ -6,6 +6,24 @@ input_file: crates/crane/src/snapshot_inputs/function_return_types.crane
 Ok:
   modules:
     - items:
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
         - kind:
             Fn:
               params: []
@@ -25,24 +43,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 16
-                                        end: 19
+                                        start: 54
+                                        end: 57
                                   - ident:
                                       name: io
                                       span:
-                                        start: 21
-                                        end: 23
+                                        start: 59
+                                        end: 61
                                   - ident:
                                       name: println
                                       span:
-                                        start: 25
-                                        end: 32
+                                        start: 63
+                                        end: 70
                                 span:
-                                  start: 16
-                                  end: 32
+                                  start: 63
+                                  end: 70
                             span:
-                              start: 16
-                              end: 32
+                              start: 88
+                              end: 95
                             ty:
                               UserDefined:
                                 module: "?"
@@ -57,24 +75,24 @@ Ok:
                                           - ident:
                                               name: std
                                               span:
-                                                start: 33
-                                                end: 36
+                                                start: 26
+                                                end: 29
                                           - ident:
                                               name: int
                                               span:
-                                                start: 38
-                                                end: 41
+                                                start: 31
+                                                end: 34
                                           - ident:
                                               name: int_to_string
                                               span:
-                                                start: 43
-                                                end: 56
+                                                start: 36
+                                                end: 49
                                         span:
-                                          start: 33
-                                          end: 56
+                                          start: 36
+                                          end: 49
                                     span:
-                                      start: 33
-                                      end: 56
+                                      start: 96
+                                      end: 109
                                     ty:
                                       UserDefined:
                                         module: "?"
@@ -89,14 +107,14 @@ Ok:
                                                   - ident:
                                                       name: add_10
                                                       span:
-                                                        start: 57
-                                                        end: 63
+                                                        start: 110
+                                                        end: 116
                                                 span:
-                                                  start: 57
-                                                  end: 63
+                                                  start: 110
+                                                  end: 116
                                             span:
-                                              start: 57
-                                              end: 63
+                                              start: 110
+                                              end: 116
                                             ty:
                                               UserDefined:
                                                 module: "?"
@@ -110,69 +128,69 @@ Ok:
                                                         - 5
                                                         - Uint64
                                                   span:
-                                                    start: 64
-                                                    end: 65
+                                                    start: 117
+                                                    end: 118
                                               span:
-                                                start: 64
-                                                end: 65
+                                                start: 117
+                                                end: 118
                                               ty:
                                                 UserDefined:
                                                   module: "std::prelude"
                                                   name: Uint64
                                       span:
-                                        start: 57
-                                        end: 63
+                                        start: 110
+                                        end: 116
                                       ty:
                                         UserDefined:
                                           module: "std::prelude"
                                           name: Uint64
                               span:
-                                start: 33
-                                end: 56
+                                start: 96
+                                end: 109
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 16
-                        end: 32
+                        start: 88
+                        end: 95
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 16
-                    end: 32
+                    start: 88
+                    end: 95
               path:
                 segments:
                   - ident:
                       name: main
                       span:
-                        start: 3
-                        end: 7
+                        start: 75
+                        end: 79
                 span:
-                  start: 3
-                  end: 7
+                  start: 75
+                  end: 79
           name:
             name: main
             span:
-              start: 3
-              end: 7
+              start: 75
+              end: 79
         - kind:
             Fn:
               params:
                 - name:
                     name: n
                     span:
-                      start: 82
-                      end: 83
+                      start: 135
+                      end: 136
                   ty:
                     UserDefined:
                       module: "std::prelude"
                       name: Uint64
                   span:
-                    start: 82
-                    end: 83
+                    start: 135
+                    end: 136
               return_ty:
                 UserDefined:
                   module: "std::prelude"
@@ -189,24 +207,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 109
-                                        end: 112
+                                        start: 4
+                                        end: 7
                                   - ident:
                                       name: int
                                       span:
-                                        start: 114
-                                        end: 117
+                                        start: 9
+                                        end: 12
                                   - ident:
                                       name: int_add
                                       span:
-                                        start: 119
-                                        end: 126
+                                        start: 14
+                                        end: 21
                                 span:
-                                  start: 109
-                                  end: 126
+                                  start: 14
+                                  end: 21
                             span:
-                              start: 109
-                              end: 126
+                              start: 162
+                              end: 169
                             ty:
                               UserDefined:
                                 module: "?"
@@ -218,14 +236,14 @@ Ok:
                                     - ident:
                                         name: n
                                         span:
-                                          start: 127
-                                          end: 128
+                                          start: 170
+                                          end: 171
                                   span:
-                                    start: 127
-                                    end: 128
+                                    start: 170
+                                    end: 171
                               span:
-                                start: 127
-                                end: 128
+                                start: 170
+                                end: 171
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
@@ -238,38 +256,38 @@ Ok:
                                         - 10
                                         - Uint64
                                   span:
-                                    start: 130
-                                    end: 132
+                                    start: 173
+                                    end: 175
                               span:
-                                start: 130
-                                end: 132
+                                start: 173
+                                end: 175
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: Uint64
                       span:
-                        start: 109
-                        end: 126
+                        start: 162
+                        end: 169
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: Uint64
                   span:
-                    start: 109
-                    end: 126
+                    start: 162
+                    end: 169
               path:
                 segments:
                   - ident:
                       name: add_10
                       span:
-                        start: 75
-                        end: 81
+                        start: 128
+                        end: 134
                 span:
-                  start: 75
-                  end: 81
+                  start: 128
+                  end: 134
           name:
             name: add_10
             span:
-              start: 75
-              end: 81
+              start: 128
+              end: 134
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
@@ -6,6 +6,12 @@ input_file: crates/crane/src/snapshot_inputs/functions.crane
 Ok:
   modules:
     - items:
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
         - kind:
             Fn:
               params: []
@@ -25,29 +31,29 @@ Ok:
                                   - ident:
                                       name: say_hello
                                       span:
-                                        start: 20
-                                        end: 29
+                                        start: 42
+                                        end: 51
                                 span:
-                                  start: 20
-                                  end: 29
+                                  start: 42
+                                  end: 51
                             span:
-                              start: 20
-                              end: 29
+                              start: 42
+                              end: 51
                             ty:
                               UserDefined:
                                 module: "?"
                                 name: "?"
                           args: []
                       span:
-                        start: 20
-                        end: 29
+                        start: 42
+                        end: 51
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 20
-                    end: 29
+                    start: 42
+                    end: 51
                 - kind:
                     Expr:
                       kind:
@@ -59,44 +65,44 @@ Ok:
                                   - ident:
                                       name: say_goodbye
                                       span:
-                                        start: 36
-                                        end: 47
+                                        start: 58
+                                        end: 69
                                 span:
-                                  start: 36
-                                  end: 47
+                                  start: 58
+                                  end: 69
                             span:
-                              start: 36
-                              end: 47
+                              start: 58
+                              end: 69
                             ty:
                               UserDefined:
                                 module: "?"
                                 name: "?"
                           args: []
                       span:
-                        start: 36
-                        end: 47
+                        start: 58
+                        end: 69
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 36
-                    end: 47
+                    start: 58
+                    end: 69
               path:
                 segments:
                   - ident:
                       name: main
                       span:
-                        start: 7
-                        end: 11
+                        start: 29
+                        end: 33
                 span:
-                  start: 7
-                  end: 11
+                  start: 29
+                  end: 33
           name:
             name: main
             span:
-              start: 7
-              end: 11
+              start: 29
+              end: 33
         - kind:
             Fn:
               params: []
@@ -116,24 +122,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 74
-                                        end: 77
+                                        start: 4
+                                        end: 7
                                   - ident:
                                       name: io
                                       span:
-                                        start: 79
-                                        end: 81
+                                        start: 9
+                                        end: 11
                                   - ident:
                                       name: println
                                       span:
-                                        start: 83
-                                        end: 90
+                                        start: 13
+                                        end: 20
                                 span:
-                                  start: 74
-                                  end: 90
+                                  start: 13
+                                  end: 20
                             span:
-                              start: 74
-                              end: 90
+                              start: 96
+                              end: 103
                             ty:
                               UserDefined:
                                 module: "?"
@@ -144,40 +150,40 @@ Ok:
                                   kind:
                                     String: "\"Hello\""
                                   span:
-                                    start: 91
-                                    end: 98
+                                    start: 104
+                                    end: 111
                               span:
-                                start: 91
-                                end: 98
+                                start: 104
+                                end: 111
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 74
-                        end: 90
+                        start: 96
+                        end: 103
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 74
-                    end: 90
+                    start: 96
+                    end: 103
               path:
                 segments:
                   - ident:
                       name: say_hello
                       span:
-                        start: 56
-                        end: 65
+                        start: 78
+                        end: 87
                 span:
-                  start: 56
-                  end: 65
+                  start: 78
+                  end: 87
           name:
             name: say_hello
             span:
-              start: 56
-              end: 65
+              start: 78
+              end: 87
         - kind:
             Fn:
               params: []
@@ -197,24 +203,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 126
-                                        end: 129
+                                        start: 4
+                                        end: 7
                                   - ident:
                                       name: io
                                       span:
-                                        start: 131
-                                        end: 133
+                                        start: 9
+                                        end: 11
                                   - ident:
                                       name: println
                                       span:
-                                        start: 135
-                                        end: 142
+                                        start: 13
+                                        end: 20
                                 span:
-                                  start: 126
-                                  end: 142
+                                  start: 13
+                                  end: 20
                             span:
-                              start: 126
-                              end: 142
+                              start: 139
+                              end: 146
                             ty:
                               UserDefined:
                                 module: "?"
@@ -225,38 +231,38 @@ Ok:
                                   kind:
                                     String: "\"Goodbye\""
                                   span:
-                                    start: 143
-                                    end: 152
+                                    start: 147
+                                    end: 156
                               span:
-                                start: 143
-                                end: 152
+                                start: 147
+                                end: 156
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 126
-                        end: 142
+                        start: 139
+                        end: 146
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 126
-                    end: 142
+                    start: 139
+                    end: 146
               path:
                 segments:
                   - ident:
                       name: say_goodbye
                       span:
-                        start: 106
-                        end: 117
+                        start: 119
+                        end: 130
                 span:
-                  start: 106
-                  end: 117
+                  start: 119
+                  end: 130
           name:
             name: say_goodbye
             span:
-              start: 106
-              end: 117
+              start: 119
+              end: 130
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
@@ -6,6 +6,12 @@ input_file: crates/crane/src/snapshot_inputs/hello_world.crane
 Ok:
   modules:
     - items:
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
         - kind:
             Fn:
               params: []
@@ -25,24 +31,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 70
-                                        end: 73
+                                        start: 4
+                                        end: 7
                                   - ident:
                                       name: io
                                       span:
-                                        start: 75
-                                        end: 77
+                                        start: 9
+                                        end: 11
                                   - ident:
                                       name: println
                                       span:
-                                        start: 79
-                                        end: 86
+                                        start: 13
+                                        end: 20
                                 span:
-                                  start: 70
-                                  end: 86
+                                  start: 13
+                                  end: 20
                             span:
-                              start: 70
-                              end: 86
+                              start: 42
+                              end: 49
                             ty:
                               UserDefined:
                                 module: "?"
@@ -53,38 +59,38 @@ Ok:
                                   kind:
                                     String: "\"Hello, world!\""
                                   span:
-                                    start: 87
-                                    end: 102
+                                    start: 50
+                                    end: 65
                               span:
-                                start: 87
-                                end: 102
+                                start: 50
+                                end: 65
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 70
-                        end: 86
+                        start: 42
+                        end: 49
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 70
-                    end: 86
+                    start: 42
+                    end: 49
               path:
                 segments:
                   - ident:
                       name: main
                       span:
-                        start: 57
-                        end: 61
+                        start: 29
+                        end: 33
                 span:
-                  start: 57
-                  end: 61
+                  start: 29
+                  end: 33
           name:
             name: main
             span:
-              start: 57
-              end: 61
+              start: 29
+              end: 33
 

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
@@ -6,6 +6,24 @@ input_file: crates/crane/src/snapshot_inputs/let_bindings.crane
 Ok:
   modules:
     - items:
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
         - kind:
             Fn:
               params: []
@@ -23,11 +41,11 @@ Ok:
                               kind:
                                 String: "\"Arya\""
                               span:
-                                start: 31
-                                end: 37
+                                start: 100
+                                end: 106
                           span:
-                            start: 31
-                            end: 37
+                            start: 100
+                            end: 106
                           ty:
                             UserDefined:
                               module: "std::prelude"
@@ -35,18 +53,18 @@ Ok:
                       name:
                         name: name
                         span:
-                          start: 24
-                          end: 28
+                          start: 93
+                          end: 97
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: String
                       span:
-                        start: 24
-                        end: 28
+                        start: 93
+                        end: 97
                   span:
-                    start: 24
-                    end: 28
+                    start: 93
+                    end: 97
                 - kind:
                     Local:
                       kind:
@@ -59,11 +77,11 @@ Ok:
                                     - 100
                                     - Uint64
                               span:
-                                start: 53
-                                end: 56
+                                start: 122
+                                end: 125
                           span:
-                            start: 53
-                            end: 56
+                            start: 122
+                            end: 125
                           ty:
                             UserDefined:
                               module: "std::prelude"
@@ -71,18 +89,18 @@ Ok:
                       name:
                         name: gold
                         span:
-                          start: 46
-                          end: 50
+                          start: 115
+                          end: 119
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: Uint64
                       span:
-                        start: 46
-                        end: 50
+                        start: 115
+                        end: 119
                   span:
-                    start: 46
-                    end: 50
+                    start: 115
+                    end: 119
                 - kind:
                     Expr:
                       kind:
@@ -94,24 +112,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 62
-                                        end: 65
+                                        start: 32
+                                        end: 35
                                   - ident:
                                       name: io
                                       span:
-                                        start: 67
-                                        end: 69
+                                        start: 37
+                                        end: 39
                                   - ident:
                                       name: print
                                       span:
-                                        start: 71
-                                        end: 76
+                                        start: 41
+                                        end: 46
                                 span:
-                                  start: 62
-                                  end: 76
+                                  start: 41
+                                  end: 46
                             span:
-                              start: 62
-                              end: 76
+                              start: 131
+                              end: 136
                             ty:
                               UserDefined:
                                 module: "?"
@@ -122,25 +140,25 @@ Ok:
                                   kind:
                                     String: "\"Hello, \""
                                   span:
-                                    start: 77
-                                    end: 86
+                                    start: 137
+                                    end: 146
                               span:
-                                start: 77
-                                end: 86
+                                start: 137
+                                end: 146
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 62
-                        end: 76
+                        start: 131
+                        end: 136
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 62
-                    end: 76
+                    start: 131
+                    end: 136
                 - kind:
                     Expr:
                       kind:
@@ -152,24 +170,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 92
-                                        end: 95
+                                        start: 32
+                                        end: 35
                                   - ident:
                                       name: io
                                       span:
-                                        start: 97
-                                        end: 99
+                                        start: 37
+                                        end: 39
                                   - ident:
                                       name: print
                                       span:
-                                        start: 101
-                                        end: 106
+                                        start: 41
+                                        end: 46
                                 span:
-                                  start: 92
-                                  end: 106
+                                  start: 41
+                                  end: 46
                             span:
-                              start: 92
-                              end: 106
+                              start: 152
+                              end: 157
                             ty:
                               UserDefined:
                                 module: "?"
@@ -181,28 +199,28 @@ Ok:
                                     - ident:
                                         name: name
                                         span:
-                                          start: 107
-                                          end: 111
+                                          start: 158
+                                          end: 162
                                   span:
-                                    start: 107
-                                    end: 111
+                                    start: 158
+                                    end: 162
                               span:
-                                start: 107
-                                end: 111
+                                start: 158
+                                end: 162
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 92
-                        end: 106
+                        start: 152
+                        end: 157
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 92
-                    end: 106
+                    start: 152
+                    end: 157
                 - kind:
                     Expr:
                       kind:
@@ -214,24 +232,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 117
-                                        end: 120
+                                        start: 51
+                                        end: 54
                                   - ident:
                                       name: io
                                       span:
-                                        start: 122
-                                        end: 124
+                                        start: 56
+                                        end: 58
                                   - ident:
                                       name: println
                                       span:
-                                        start: 126
-                                        end: 133
+                                        start: 60
+                                        end: 67
                                 span:
-                                  start: 117
-                                  end: 133
+                                  start: 60
+                                  end: 67
                             span:
-                              start: 117
-                              end: 133
+                              start: 168
+                              end: 175
                             ty:
                               UserDefined:
                                 module: "?"
@@ -242,25 +260,25 @@ Ok:
                                   kind:
                                     String: "\".\""
                                   span:
-                                    start: 134
-                                    end: 137
+                                    start: 176
+                                    end: 179
                               span:
-                                start: 134
-                                end: 137
+                                start: 176
+                                end: 179
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 117
-                        end: 133
+                        start: 168
+                        end: 175
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 117
-                    end: 133
+                    start: 168
+                    end: 175
                 - kind:
                     Expr:
                       kind:
@@ -272,24 +290,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 144
-                                        end: 147
+                                        start: 32
+                                        end: 35
                                   - ident:
                                       name: io
                                       span:
-                                        start: 149
-                                        end: 151
+                                        start: 37
+                                        end: 39
                                   - ident:
                                       name: print
                                       span:
-                                        start: 153
-                                        end: 158
+                                        start: 41
+                                        end: 46
                                 span:
-                                  start: 144
-                                  end: 158
+                                  start: 41
+                                  end: 46
                             span:
-                              start: 144
-                              end: 158
+                              start: 186
+                              end: 191
                             ty:
                               UserDefined:
                                 module: "?"
@@ -300,25 +318,25 @@ Ok:
                                   kind:
                                     String: "\"You currently have \""
                                   span:
-                                    start: 159
-                                    end: 180
+                                    start: 192
+                                    end: 213
                               span:
-                                start: 159
-                                end: 180
+                                start: 192
+                                end: 213
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 144
-                        end: 158
+                        start: 186
+                        end: 191
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 144
-                    end: 158
+                    start: 186
+                    end: 191
                 - kind:
                     Expr:
                       kind:
@@ -330,24 +348,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 186
-                                        end: 189
+                                        start: 32
+                                        end: 35
                                   - ident:
                                       name: io
                                       span:
-                                        start: 191
-                                        end: 193
+                                        start: 37
+                                        end: 39
                                   - ident:
                                       name: print
                                       span:
-                                        start: 195
-                                        end: 200
+                                        start: 41
+                                        end: 46
                                 span:
-                                  start: 186
-                                  end: 200
+                                  start: 41
+                                  end: 46
                             span:
-                              start: 186
-                              end: 200
+                              start: 219
+                              end: 224
                             ty:
                               UserDefined:
                                 module: "?"
@@ -362,24 +380,24 @@ Ok:
                                           - ident:
                                               name: std
                                               span:
-                                                start: 201
-                                                end: 204
+                                                start: 4
+                                                end: 7
                                           - ident:
                                               name: int
                                               span:
-                                                start: 206
-                                                end: 209
+                                                start: 9
+                                                end: 12
                                           - ident:
                                               name: int_to_string
                                               span:
-                                                start: 211
-                                                end: 224
+                                                start: 14
+                                                end: 27
                                         span:
-                                          start: 201
-                                          end: 224
+                                          start: 14
+                                          end: 27
                                     span:
-                                      start: 201
-                                      end: 224
+                                      start: 225
+                                      end: 238
                                     ty:
                                       UserDefined:
                                         module: "?"
@@ -391,35 +409,35 @@ Ok:
                                             - ident:
                                                 name: gold
                                                 span:
-                                                  start: 225
-                                                  end: 229
+                                                  start: 239
+                                                  end: 243
                                           span:
-                                            start: 225
-                                            end: 229
+                                            start: 239
+                                            end: 243
                                       span:
-                                        start: 225
-                                        end: 229
+                                        start: 239
+                                        end: 243
                                       ty:
                                         UserDefined:
                                           module: "std::prelude"
                                           name: Uint64
                               span:
-                                start: 201
-                                end: 224
+                                start: 225
+                                end: 238
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 186
-                        end: 200
+                        start: 219
+                        end: 224
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 186
-                    end: 200
+                    start: 219
+                    end: 224
                 - kind:
                     Expr:
                       kind:
@@ -431,24 +449,24 @@ Ok:
                                   - ident:
                                       name: std
                                       span:
-                                        start: 236
-                                        end: 239
+                                        start: 51
+                                        end: 54
                                   - ident:
                                       name: io
                                       span:
-                                        start: 241
-                                        end: 243
+                                        start: 56
+                                        end: 58
                                   - ident:
                                       name: println
                                       span:
-                                        start: 245
-                                        end: 252
+                                        start: 60
+                                        end: 67
                                 span:
-                                  start: 236
-                                  end: 252
+                                  start: 60
+                                  end: 67
                             span:
-                              start: 236
-                              end: 252
+                              start: 250
+                              end: 257
                             ty:
                               UserDefined:
                                 module: "?"
@@ -459,38 +477,38 @@ Ok:
                                   kind:
                                     String: "\" gold at your disposal.\""
                                   span:
-                                    start: 253
-                                    end: 278
+                                    start: 258
+                                    end: 283
                               span:
-                                start: 253
-                                end: 278
+                                start: 258
+                                end: 283
                               ty:
                                 UserDefined:
                                   module: "std::prelude"
                                   name: String
                       span:
-                        start: 236
-                        end: 252
+                        start: 250
+                        end: 257
                       ty:
                         UserDefined:
                           module: "std::prelude"
                           name: ()
                   span:
-                    start: 236
-                    end: 252
+                    start: 250
+                    end: 257
               path:
                 segments:
                   - ident:
                       name: main
                       span:
-                        start: 7
-                        end: 11
+                        start: 76
+                        end: 80
                 span:
-                  start: 7
-                  end: 11
+                  start: 76
+                  end: 80
           name:
             name: main
             span:
-              start: 7
-              end: 11
+              start: 76
+              end: 80
 

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -100,8 +100,6 @@ impl Typer {
         params: ThinVec<TyFnParam>,
         return_ty: Arc<Type>,
     ) {
-        tracing::trace!("Registering function {}::{}", &module_path, &name);
-
         let module = self.modules.entry(module_path).or_default();
         module.insert(name, (params, return_ty));
     }

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -38,10 +38,10 @@ fn ty_to_string(ty: &Type) -> String {
 
 pub type TypeCheckResult<T> = Result<T, TypeError>;
 
-type ModuleFunctions = HashMap<TyPath, (ThinVec<TyFnParam>, Arc<Type>)>;
+type ModuleFunctions = HashMap<Ident, (ThinVec<TyFnParam>, Arc<Type>)>;
 
 pub struct Typer {
-    module_functions: ModuleFunctions,
+    modules: HashMap<TyPath, ModuleFunctions>,
     scopes: Vec<HashMap<TyPath, Arc<Type>>>,
 
     // Types.
@@ -68,7 +68,7 @@ impl Typer {
         });
 
         Self {
-            module_functions: HashMap::new(),
+            modules: HashMap::new(),
             scopes: Vec::new(),
             unit_ty,
             string_ty,
@@ -100,34 +100,44 @@ impl Typer {
         params: ThinVec<TyFnParam>,
         return_ty: Arc<Type>,
     ) {
-        let mut path_segments = module_path.segments.clone();
-        path_segments.push(TyPathSegment {
-            ident: name.clone(),
-        });
+        tracing::trace!("Registering function {}::{}", &module_path, &name);
 
-        let path = TyPath {
-            segments: path_segments,
-            span: DUMMY_SPAN,
-        };
-
-        self.module_functions.insert(path, (params, return_ty));
+        let module = self.modules.entry(module_path).or_default();
+        module.insert(name, (params, return_ty));
     }
 
     fn ensure_function_exists(
         &self,
         path: &TyPath,
     ) -> TypeCheckResult<(&ThinVec<TyFnParam>, Arc<Type>)> {
-        if let Some((params, return_ty)) = self.module_functions.get(path) {
+        let (TyPathSegment { ident: name }, module_path_segments) =
+            path.segments.split_last().unwrap();
+
+        let module_path = TyPath {
+            segments: module_path_segments.into(),
+            span: path.span,
+        };
+
+        let module = self.modules.get(&module_path).ok_or_else(|| TypeError {
+            kind: TypeErrorKind::Error(format!("Unknown module `{}`.", module_path)),
+            span: path.span,
+        })?;
+
+        if let Some((params, return_ty)) = module.get(name) {
             return Ok((params, return_ty.clone()));
         }
 
         Err(TypeError {
             kind: TypeErrorKind::UnknownFunction {
                 path: path.clone(),
-                options: self
-                    .module_functions
+                options: module
                     .keys()
-                    .cloned()
+                    .map(|name| TyPath {
+                        segments: thin_vec![TyPathSegment {
+                            ident: name.clone()
+                        }],
+                        span: name.span,
+                    })
                     .collect::<ThinVec<_>>(),
             },
             span: path.span,

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -11,6 +11,10 @@ pub struct TypeError {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TypeErrorKind {
+    UnknownModule {
+        path: TyPath,
+        options: ThinVec<TyPath>,
+    },
     UnknownFunction {
         path: TyPath,
         options: ThinVec<TyPath>,

--- a/examples/functions.crane
+++ b/examples/functions.crane
@@ -1,5 +1,4 @@
-// TODO: Handle imports.
-// use std::io::println
+use std::io::println
 
 pub fn main() {
     say_hello()
@@ -7,9 +6,9 @@ pub fn main() {
 }
 
 fn say_hello() {
-    std::io::println("Hello")
+    println("Hello")
 }
 
 fn say_goodbye() {
-    std::io::println("Goodbye")
+    println("Goodbye")
 }

--- a/examples/hello_world.crane
+++ b/examples/hello_world.crane
@@ -1,6 +1,5 @@
-// TODO: Handle imports.
-// use std::io::println
+use std::io::println
 
 pub fn main() {
-    std::io::println("Hello, world!")
+    println("Hello, world!")
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -1,3 +1,5 @@
+use std::int::int_add
+use std::int::int_to_string
 use std::io::print
 use std::io::println
 
@@ -19,40 +21,40 @@ pub fn main() {
     foo::do_foo()
     foo::bar::do_bar()
 
-    std::io::print("twenty_three = ")
-    std::io::println(std::int::int_to_string(twenty_three))
-    std::io::println(" ")
+    print("twenty_three = ")
+    println(int_to_string(twenty_three))
+    println(" ")
 
     let greeting = "Hey"
 
-    std::io::print("greeting = ")
-    std::io::println(greeting)
-    std::io::println(" ")
+    print("greeting = ")
+    println(greeting)
+    println(" ")
 
     greet("world")
     greet("trees")
     greet("everyone")
-    std::io::println("")
+    println("")
 
-    std::io::print("This value is always ")
-    std::io::println(std::int::int_to_string(always_3()))
-    std::io::println("")
+    print("This value is always ")
+    println(int_to_string(always_3()))
+    println("")
 
     let also_always_3 = always_3()
-    std::io::print("This value is also always ")
-    std::io::println(std::int::int_to_string(also_always_3))
-    std::io::println("")
+    print("This value is also always ")
+    println(int_to_string(also_always_3))
+    println("")
 
-    let ten = std::int::int_add(also_always_3, 7)
-    std::io::print("This value should be 10: ")
-    std::io::println(std::int::int_to_string(ten))
-    std::io::println("")
+    let ten = int_add(also_always_3, 7)
+    print("This value should be 10: ")
+    println(int_to_string(ten))
+    println("")
 
     add_and_print(1, 1)
     add_and_print(2, 2)
     add_and_print(3, 3)
-    std::io::print("7 + 5 = ")
-    std::io::println(std::int::int_to_string(add_5(7)))
+    print("7 + 5 = ")
+    println(int_to_string(add_5(7)))
 }
 
 fn always_3() -> Uint64 {
@@ -60,38 +62,38 @@ fn always_3() -> Uint64 {
 }
 
 fn add_5(value: Uint64) -> Uint64 {
-    std::int::int_add(value, 5)
+    int_add(value, 5)
 }
 
 fn greet(name: String) {
     join("Hello", name)
-    std::io::print("!")
-    std::io::println("")
+    print("!")
+    println("")
 }
 
 fn join(a: String, b: String) {
-    std::io::print(a)
-    std::io::print(", ")
-    std::io::print(b)
+    print(a)
+    print(", ")
+    print(b)
 }
 
 fn add_and_print(a: Uint64, b: Uint64) {
-    std::io::print(std::int::int_to_string(a))
-    std::io::print(" + ")
-    std::io::print(std::int::int_to_string(b))
-    std::io::print(" = ")
-    std::io::print(std::int::int_to_string(std::int::int_add(a, b)))
-    std::io::println("")
+    print(int_to_string(a))
+    print(" + ")
+    print(int_to_string(b))
+    print(" = ")
+    print(int_to_string(int_add(a, b)))
+    println("")
 }
 
 mod foo {
     fn do_foo() {
-        std::io::println("Hello from `foo`")
+        println("Hello from `foo`")
     }
 
     mod bar {
         fn do_bar() {
-            std::io::println("Hello from `bar`")
+            println("Hello from `bar`")
         }
     }
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -14,6 +14,8 @@ union Bool {
 pub fn main() {
     let twenty_three = 23
 
+    println("Hey")
+
     foo::do_foo()
     foo::bar::do_bar()
 


### PR DESCRIPTION
This PR makes `use` work for bringing functions into scope.

Previously it was only possible to call functions within modules by fully qualifying the name:

```rs
fn main() {
    std::io::println("Hello")
}
```

Now, however, we can use a `use` item to bring the function into scope and refer to it just by its name:

```rs
use std::io::println

fn main() {
    println("Hello")
}
```