### PR TITLE
Distinguish between comments and doc comments during lexing

### DIFF
--- a/crates/crane/src/lexer/token.rs
+++ b/crates/crane/src/lexer/token.rs
@@ -60,6 +60,10 @@ pub enum TokenKind {
     #[regex(r"//.*")]
     Comment,
 
+    /// A documentation comment.
+    #[regex(r"///.*")]
+    DocComment,
+
     /// Any sequence of whitespace characters.
     #[regex(r"[ \n]+", logos::skip)]
     Whitespace,

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -123,7 +123,7 @@ where
             match self.tokens.next() {
                 // Ignore any comment tokens.
                 Some(Ok(Token {
-                    kind: TokenKind::Comment,
+                    kind: TokenKind::Comment | TokenKind::DocComment,
                     ..
                 })) => {
                     continue;

--- a/crates/crane/src/snapshot_inputs/comments.crane
+++ b/crates/crane/src/snapshot_inputs/comments.crane
@@ -1,0 +1,11 @@
+use std::io::println
+
+fn main() {
+    println(always_blue())
+}
+
+/// Always returns the string "blue".
+fn always_blue() -> String {
+    // Always blue! Always blue!
+    "blue"
+}

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@comments.crane.snap
@@ -1,0 +1,180 @@
+---
+source: crates/crane/src/lexer.rs
+expression: "lexer.into_iter().collect::<Vec<_>>()"
+input_file: crates/crane/src/snapshot_inputs/comments.crane
+---
+- Ok:
+    kind: Ident
+    lexeme: use
+    span:
+      start: 0
+      end: 3
+- Ok:
+    kind: Ident
+    lexeme: std
+    span:
+      start: 4
+      end: 7
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 7
+      end: 9
+- Ok:
+    kind: Ident
+    lexeme: io
+    span:
+      start: 9
+      end: 11
+- Ok:
+    kind: ColonColon
+    lexeme: "::"
+    span:
+      start: 11
+      end: 13
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 13
+      end: 20
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 22
+      end: 24
+- Ok:
+    kind: Ident
+    lexeme: main
+    span:
+      start: 25
+      end: 29
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 29
+      end: 30
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 30
+      end: 31
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 32
+      end: 33
+- Ok:
+    kind: Ident
+    lexeme: println
+    span:
+      start: 38
+      end: 45
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 45
+      end: 46
+- Ok:
+    kind: Ident
+    lexeme: always_blue
+    span:
+      start: 46
+      end: 57
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 57
+      end: 58
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 58
+      end: 59
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 59
+      end: 60
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 61
+      end: 62
+- Ok:
+    kind: Comment
+    lexeme: "/// Always returns the string \"blue\"."
+    span:
+      start: 64
+      end: 101
+- Ok:
+    kind: Ident
+    lexeme: fn
+    span:
+      start: 102
+      end: 104
+- Ok:
+    kind: Ident
+    lexeme: always_blue
+    span:
+      start: 105
+      end: 116
+- Ok:
+    kind: OpenParen
+    lexeme: (
+    span:
+      start: 116
+      end: 117
+- Ok:
+    kind: CloseParen
+    lexeme: )
+    span:
+      start: 117
+      end: 118
+- Ok:
+    kind: RightArrow
+    lexeme: "->"
+    span:
+      start: 119
+      end: 121
+- Ok:
+    kind: Ident
+    lexeme: String
+    span:
+      start: 122
+      end: 128
+- Ok:
+    kind: OpenBrace
+    lexeme: "{"
+    span:
+      start: 129
+      end: 130
+- Ok:
+    kind: Comment
+    lexeme: // Always blue! Always blue!
+    span:
+      start: 135
+      end: 163
+- Ok:
+    kind: String
+    lexeme: "\"blue\""
+    span:
+      start: 168
+      end: 174
+- Ok:
+    kind: CloseBrace
+    lexeme: "}"
+    span:
+      start: 175
+      end: 176
+

--- a/crates/crane/src/snapshots/crane__lexer__tests__lexer@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__lexer__tests__lexer@comments.crane.snap
@@ -112,7 +112,7 @@ input_file: crates/crane/src/snapshot_inputs/comments.crane
       start: 61
       end: 62
 - Ok:
-    kind: Comment
+    kind: DocComment
     lexeme: "/// Always returns the string \"blue\"."
     span:
       start: 64

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
@@ -1,0 +1,118 @@
+---
+source: crates/crane/src/parser.rs
+expression: parser.parse()
+input_file: crates/crane/src/snapshot_inputs/comments.crane
+---
+Ok:
+  - kind:
+      Use:
+        prefix:
+          segments:
+            - ident:
+                name: std
+                span:
+                  start: 4
+                  end: 7
+            - ident:
+                name: io
+                span:
+                  start: 9
+                  end: 11
+            - ident:
+                name: println
+                span:
+                  start: 13
+                  end: 20
+          span:
+            start: 0
+            end: 0
+        kind: Single
+    name:
+      name: ""
+      span:
+        start: 0
+        end: 0
+  - kind:
+      Fn:
+        params: []
+        return_ty: ~
+        body:
+          - kind:
+              Expr:
+                kind:
+                  Call:
+                    fun:
+                      kind:
+                        Variable:
+                          segments:
+                            - ident:
+                                name: println
+                                span:
+                                  start: 38
+                                  end: 45
+                          span:
+                            start: 38
+                            end: 45
+                      span:
+                        start: 38
+                        end: 45
+                    args:
+                      - kind:
+                          Call:
+                            fun:
+                              kind:
+                                Variable:
+                                  segments:
+                                    - ident:
+                                        name: always_blue
+                                        span:
+                                          start: 46
+                                          end: 57
+                                  span:
+                                    start: 46
+                                    end: 57
+                              span:
+                                start: 46
+                                end: 57
+                            args: []
+                        span:
+                          start: 46
+                          end: 57
+                span:
+                  start: 38
+                  end: 45
+            span:
+              start: 38
+              end: 45
+    name:
+      name: main
+      span:
+        start: 25
+        end: 29
+  - kind:
+      Fn:
+        params: []
+        return_ty:
+          name: String
+          span:
+            start: 122
+            end: 128
+        body:
+          - kind:
+              Expr:
+                kind:
+                  Literal:
+                    kind: String
+                    value: "\"blue\""
+                span:
+                  start: 168
+                  end: 174
+            span:
+              start: 168
+              end: 174
+    name:
+      name: always_blue
+      span:
+        start: 105
+        end: 116
+

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@comments.crane.snap
@@ -1,0 +1,153 @@
+---
+source: crates/crane/src/typer.rs
+expression: typer.type_check_package(package)
+input_file: crates/crane/src/snapshot_inputs/comments.crane
+---
+Ok:
+  modules:
+    - items:
+        - kind: Use
+          name:
+            name: ""
+            span:
+              start: 0
+              end: 0
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: ()
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Call:
+                          fun:
+                            kind:
+                              Variable:
+                                segments:
+                                  - ident:
+                                      name: std
+                                      span:
+                                        start: 4
+                                        end: 7
+                                  - ident:
+                                      name: io
+                                      span:
+                                        start: 9
+                                        end: 11
+                                  - ident:
+                                      name: println
+                                      span:
+                                        start: 13
+                                        end: 20
+                                span:
+                                  start: 13
+                                  end: 20
+                            span:
+                              start: 38
+                              end: 45
+                            ty:
+                              UserDefined:
+                                module: "?"
+                                name: "?"
+                          args:
+                            - kind:
+                                Call:
+                                  fun:
+                                    kind:
+                                      Variable:
+                                        segments:
+                                          - ident:
+                                              name: always_blue
+                                              span:
+                                                start: 46
+                                                end: 57
+                                        span:
+                                          start: 46
+                                          end: 57
+                                    span:
+                                      start: 46
+                                      end: 57
+                                    ty:
+                                      UserDefined:
+                                        module: "?"
+                                        name: "?"
+                                  args: []
+                              span:
+                                start: 46
+                                end: 57
+                              ty:
+                                UserDefined:
+                                  module: "std::prelude"
+                                  name: String
+                      span:
+                        start: 38
+                        end: 45
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: ()
+                  span:
+                    start: 38
+                    end: 45
+              path:
+                segments:
+                  - ident:
+                      name: main
+                      span:
+                        start: 25
+                        end: 29
+                span:
+                  start: 25
+                  end: 29
+          name:
+            name: main
+            span:
+              start: 25
+              end: 29
+        - kind:
+            Fn:
+              params: []
+              return_ty:
+                UserDefined:
+                  module: "std::prelude"
+                  name: String
+              body:
+                - kind:
+                    Expr:
+                      kind:
+                        Literal:
+                          kind:
+                            String: "\"blue\""
+                          span:
+                            start: 168
+                            end: 174
+                      span:
+                        start: 168
+                        end: 174
+                      ty:
+                        UserDefined:
+                          module: "std::prelude"
+                          name: String
+                  span:
+                    start: 168
+                    end: 174
+              path:
+                segments:
+                  - ident:
+                      name: always_blue
+                      span:
+                        start: 105
+                        end: 116
+                span:
+                  start: 105
+                  end: 116
+          name:
+            name: always_blue
+            span:
+              start: 105
+              end: 116
+


### PR DESCRIPTION
This PR makes the lexer treat comments (`//`) and doc comments (`///`) as different tokens.

At present this doesn't make any difference from a parsing perspective, as doc comments were already parsable, but just as regular comments.

In the future, however, we will want to be able to distinguish between the two so we can extract doc comments (e.g., in generated documentation).