### PR TITLE
Use already-defined prelude types

### DIFF
--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -749,10 +749,7 @@ impl Typer {
                 span,
             }),
             span,
-            ty: Arc::new(Type::UserDefined {
-                module: "std::prelude".into(),
-                name: "String".into(),
-            }),
+            ty: self.string_ty.clone(),
         })
     }
 
@@ -765,10 +762,7 @@ impl Typer {
                 span,
             }),
             span,
-            ty: Arc::new(Type::UserDefined {
-                module: "std::prelude".into(),
-                name: "Uint64".into(),
-            }),
+            ty: self.uint64_ty.clone(),
         })
     }
 }


### PR DESCRIPTION
This PR updates some spots in the `Typer` to use the already-defined prelude types.