### PR TITLE
Require function names to be snake_cased

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "clap",
+ "heck",
  "inkwell",
  "insta",
  "itertools",

--- a/crates/crane/Cargo.toml
+++ b/crates/crane/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 ariadne = "0.3.0"
 clap = { version = "4.3.3", features = ["derive"] }
+heck = "0.4.1"
 inkwell = { version = "0.2.0", features = ["llvm16-0"] }
 itertools = "0.10.5"
 logos = "0.13.0"

--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -141,6 +141,23 @@ fn compile(example: Option<String>) -> Result<(), ()> {
                     let example_file = example_file.display().to_string();
 
                     let error_report = match type_error.kind {
+                        TypeErrorKind::InvalidFunctionName { reason, suggestion } => {
+                            Report::build(ReportKind::Error, &example_file, 1)
+                                .with_message("A type error occurred.")
+                                .with_label(
+                                    Label::new(SourceSpan::from((&example_file, span)))
+                                        .with_message(reason)
+                                        .with_color(Color::Red),
+                                )
+                                .with_label(
+                                    Label::new(SourceSpan::from((&example_file, span)))
+                                        .with_message(format!(
+                                            "Try writing it as `{suggestion}` instead."
+                                        ))
+                                        .with_color(Color::Cyan),
+                                )
+                                .finish()
+                        }
                         TypeErrorKind::UnknownModule { path, options } => {
                             let report = Report::build(ReportKind::Error, &example_file, 1)
                                 .with_message("A type error occurred.")

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -3,12 +3,12 @@ mod error;
 mod r#type;
 
 pub use error::*;
-use heck::ToSnakeCase;
 pub use r#type::*;
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use heck::ToSnakeCase;
 use smol_str::SmolStr;
 use thin_vec::{thin_vec, ThinVec};
 
@@ -312,7 +312,12 @@ impl Typer {
                         span: DUMMY_SPAN,
                     };
 
-                    self.register_function(module_path, item.name.clone(), typed_params, return_ty)?;
+                    self.register_function(
+                        module_path,
+                        item.name.clone(),
+                        typed_params,
+                        return_ty,
+                    )?;
                 }
                 ItemKind::Struct(_) => {}
                 ItemKind::Union(_) => {}

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -3,6 +3,7 @@ mod error;
 mod r#type;
 
 pub use error::*;
+use heck::ToSnakeCase;
 pub use r#type::*;
 
 use std::collections::HashMap;
@@ -80,7 +81,7 @@ impl Typer {
 
     pub fn type_check_package(&mut self, package: Package) -> TypeCheckResult<TyPackage> {
         // HACK: Register the functions from `std`.
-        self.register_std();
+        self.register_std()?;
 
         self.perform_function_registration_pass(&package)?;
 
@@ -101,9 +102,21 @@ impl Typer {
         name: Ident,
         params: ThinVec<TyFnParam>,
         return_ty: Arc<Type>,
-    ) {
+    ) -> TypeCheckResult<()> {
+        if name.name != name.name.to_snake_case() {
+            return Err(TypeError {
+                kind: TypeErrorKind::InvalidFunctionName {
+                    reason: "Function names must be written in snake_case.".to_string(),
+                    suggestion: name.name.to_snake_case().into(),
+                },
+                span: name.span,
+            })?;
+        }
+
         let module = self.modules.entry(module_path).or_default();
         module.insert(name, (params, return_ty));
+
+        Ok(())
     }
 
     fn ensure_function_exists(
@@ -147,7 +160,7 @@ impl Typer {
         })
     }
 
-    fn register_std(&mut self) {
+    fn register_std(&mut self) -> TypeCheckResult<()> {
         let std_io_path = TyPath {
             segments: thin_vec![
                 TyPathSegment {
@@ -199,7 +212,7 @@ impl Typer {
                 span: DUMMY_SPAN
             }],
             self.unit_ty.clone(),
-        );
+        )?;
         self.register_function(
             std_io_path,
             Ident {
@@ -215,7 +228,7 @@ impl Typer {
                 span: DUMMY_SPAN
             }],
             self.unit_ty.clone(),
-        );
+        )?;
         self.register_function(
             std_int_path.clone(),
             Ident {
@@ -241,7 +254,7 @@ impl Typer {
                 }
             ],
             self.uint64_ty.clone(),
-        );
+        )?;
         self.register_function(
             std_int_path,
             Ident {
@@ -257,7 +270,9 @@ impl Typer {
                 span: DUMMY_SPAN
             }],
             self.string_ty.clone(),
-        );
+        )?;
+
+        Ok(())
     }
 
     fn perform_function_registration_pass(&mut self, package: &Package) -> TypeCheckResult<()> {
@@ -297,7 +312,7 @@ impl Typer {
                         span: DUMMY_SPAN,
                     };
 
-                    self.register_function(module_path, item.name.clone(), typed_params, return_ty)
+                    self.register_function(module_path, item.name.clone(), typed_params, return_ty)?;
                 }
                 ItemKind::Struct(_) => {}
                 ItemKind::Union(_) => {}

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
 use crate::ast::{Span, TyPath};
@@ -11,6 +12,10 @@ pub struct TypeError {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TypeErrorKind {
+    InvalidFunctionName {
+        reason: String,
+        suggestion: SmolStr,
+    },
     UnknownModule {
         path: TyPath,
         options: ThinVec<TyPath>,

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -18,6 +18,8 @@ pub fn main() {
 
     println("Hey")
 
+    lolCamelCase()
+
     foo::do_foo()
     foo::bar::do_bar()
 
@@ -55,6 +57,10 @@ pub fn main() {
     add_and_print(3, 3)
     print("7 + 5 = ")
     println(int_to_string(add_5(7)))
+}
+
+fn lolCamelCase() {
+    println("This shouldn't be allowed")
 }
 
 fn always_3() -> Uint64 {

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -18,8 +18,6 @@ pub fn main() {
 
     println("Hey")
 
-    lolCamelCase()
-
     foo::do_foo()
     foo::bar::do_bar()
 
@@ -57,10 +55,6 @@ pub fn main() {
     add_and_print(3, 3)
     print("7 + 5 = ")
     println(int_to_string(add_5(7)))
-}
-
-fn lolCamelCase() {
-    println("This shouldn't be allowed")
 }
 
 fn always_3() -> Uint64 {


### PR DESCRIPTION
This PR makes the compiler enforce that function names are written in snake_case.

<img width="1309" alt="Screenshot 2023-06-19 at 8 55 44 PM" src="https://github.com/crane-lang/crane/assets/1486634/9f627c84-aa88-4cd6-aa7f-a4c01fb36a9f">
