### PR TITLE
Add first compiler UI test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,7 @@ dependencies = [
  "logos",
  "serde",
  "smol_str",
+ "strip-ansi-escapes",
  "strsim",
  "thin-vec",
  "thiserror",
@@ -614,6 +621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +766,27 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/crane/Cargo.toml
+++ b/crates/crane/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = "0.3.17"
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["yaml", "glob"] }
+strip-ansi-escapes = "0.1.1"
 
 [profile.dev.package.insta]
 opt-level = 3

--- a/crates/crane/src/compiler.rs
+++ b/crates/crane/src/compiler.rs
@@ -244,7 +244,7 @@ fn inCamelCase() {}
 
         let _ = compiler.compile(&mut stderr, params);
 
-        let stderr: Vec<u8> = strip_ansi_escapes::strip(stderr).unwrap();
+        let stderr = strip_ansi_escapes::strip(stderr).unwrap();
         let stderr = std::str::from_utf8(&stderr).unwrap();
 
         insta::assert_snapshot!(&stderr);

--- a/crates/crane/src/main.rs
+++ b/crates/crane/src/main.rs
@@ -105,7 +105,7 @@ fn compile(example: Option<String>) -> Result<(), ()> {
         input: Input::File(example_file),
     };
 
-    compiler.compile(params)
+    compiler.compile(&mut std::io::stderr(), params)
 }
 
 fn run() {

--- a/crates/crane/src/snapshots/crane__compiler__tests__camel_case_function_name.snap
+++ b/crates/crane/src/snapshots/crane__compiler__tests__camel_case_function_name.snap
@@ -1,0 +1,14 @@
+---
+source: crates/crane/src/compiler.rs
+expression: "&stderr"
+---
+Error: A type error occurred.
+   ╭─[camel_case.crane:1:2]
+   │
+ 3 │ fn inCamelCase() {}
+   │    ─────┬─────  
+   │         ╰─────── Function names must be written in snake_case.
+   │         │       
+   │         ╰─────── Try writing it as `in_camel_case` instead.
+───╯
+


### PR DESCRIPTION
This PR adds the first test on the actual compiler UI.

It is setup to use snapshot tests like the rest of the test suite.