### PR TITLE
Explicitly represent types in AST

### DIFF
--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -278,7 +278,7 @@ mod tests {
 
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"32");
-        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"56");
+        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"24");
         insta::assert_snapshot!(size_of::<Item>().to_string(), @"72");
         insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"32");

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -283,5 +283,7 @@ mod tests {
         insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<StmtKind>().to_string(), @"16");
+        insta::assert_snapshot!(size_of::<Ty>().to_string(), @"40");
+        insta::assert_snapshot!(size_of::<TyKind>().to_string(), @"24");
     }
 }

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -19,6 +19,20 @@ pub struct PathSegment {
     pub ident: Ident,
 }
 
+/// The kind of a [`Ty`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TyKind {
+    /// A type referenced by its path.
+    Path(Path),
+}
+
+/// A type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ty {
+    pub kind: TyKind,
+    pub span: Span,
+}
+
 /// The kind of an [`Expr`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExprKind {
@@ -94,7 +108,7 @@ impl LocalKind {
 pub struct Local {
     pub kind: LocalKind,
     pub name: Ident,
-    pub ty: Option<Box<Ident>>,
+    pub ty: Option<Box<Ty>>,
     pub span: Span,
 }
 
@@ -115,7 +129,7 @@ pub struct UseTree {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fn {
     pub params: ThinVec<FnParam>,
-    pub return_ty: Option<Ident>,
+    pub return_ty: FnReturnTy,
     pub body: ThinVec<Stmt>,
 }
 
@@ -123,8 +137,20 @@ pub struct Fn {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FnParam {
     pub name: Ident,
-    pub ty: Ident,
+    pub ty: Box<Ty>,
     pub span: Span,
+}
+
+/// The return type of a [`Fn`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FnReturnTy {
+    /// The unit type `()`.
+    ///
+    /// This is the default return type if one is not specified.
+    Unit,
+
+    /// Any other type.
+    Ty(Box<Ty>),
 }
 
 /// A statement.
@@ -138,7 +164,7 @@ pub struct Stmt {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldDecl {
     pub name: Option<Ident>,
-    pub ty: Ident,
+    pub ty: Box<Ty>,
     pub span: Span,
 }
 

--- a/crates/crane/src/ast/visitor.rs
+++ b/crates/crane/src/ast/visitor.rs
@@ -1,12 +1,13 @@
 use crate::ast::{
-    Expr, ExprKind, FieldDecl, Fn, FnParam, Ident, Item, ItemKind, Local, ModuleDecl, Path,
-    PathSegment, Stmt, StmtKind, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant, VariantData,
+    Expr, ExprKind, FieldDecl, Fn, FnParam, FnReturnTy, Ident, Item, ItemKind, Local, ModuleDecl,
+    Path, PathSegment, Stmt, StmtKind, StructDecl, Ty, UnionDecl, UseTree, UseTreeKind, Variant,
+    VariantData,
 };
 
 pub trait Visitor: Sized {
     fn visit_ident(&mut self, _ident: &Ident) {}
 
-    fn visit_ty(&mut self, _ty: &Ident) {}
+    fn visit_ty(&mut self, _ty: &Ty) {}
 
     fn visit_item(&mut self, item: &Item) {
         walk_item(self, item);
@@ -30,6 +31,10 @@ pub trait Visitor: Sized {
 
     fn visit_fn_param(&mut self, param: &FnParam) {
         walk_fn_param(self, param);
+    }
+
+    fn visit_fn_return_ty(&mut self, return_ty: &FnReturnTy) {
+        walk_fn_return_ty(self, return_ty);
     }
 
     fn visit_struct_decl(&mut self, struct_decl: &StructDecl) {
@@ -114,6 +119,8 @@ pub fn walk_fn<V: Visitor>(visitor: &mut V, fun: &Fn) {
         visitor.visit_fn_param(param);
     }
 
+    visitor.visit_fn_return_ty(&fun.return_ty);
+
     for stmt in &fun.body {
         visitor.visit_stmt(stmt);
     }
@@ -122,6 +129,15 @@ pub fn walk_fn<V: Visitor>(visitor: &mut V, fun: &Fn) {
 pub fn walk_fn_param<V: Visitor>(visitor: &mut V, param: &FnParam) {
     visitor.visit_ident(&param.name);
     visitor.visit_ty(&param.ty);
+}
+
+pub fn walk_fn_return_ty<V: Visitor>(visitor: &mut V, return_ty: &FnReturnTy) {
+    match &return_ty {
+        FnReturnTy::Ty(ty) => {
+            visitor.visit_ty(ty);
+        }
+        FnReturnTy::Unit => {}
+    }
 }
 
 pub fn walk_struct_decl<V: Visitor>(visitor: &mut V, struct_decl: &StructDecl) {

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -2,6 +2,7 @@ mod error;
 mod expr;
 mod item;
 mod stmt;
+mod ty;
 
 pub use error::*;
 

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -1,9 +1,9 @@
 use thin_vec::ThinVec;
 
 use crate::ast::{
-    keywords, FieldDecl, Fn, FnParam, Ident, InlineModuleDecl, Item, ItemKind, Module, ModuleDecl,
-    Path, PathSegment, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant, VariantData,
-    DUMMY_SPAN,
+    keywords, FieldDecl, Fn, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind, Module,
+    ModuleDecl, Path, PathSegment, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant,
+    VariantData, DUMMY_SPAN,
 };
 use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
@@ -100,13 +100,13 @@ where
 
                 self.consume(TokenKind::Colon);
 
-                let ty_annotation = self.parse_ident()?;
+                let ty = self.parse_ty()?;
 
                 let span = param_name.span;
 
                 params.push(FnParam {
                     name: param_name,
-                    ty: ty_annotation,
+                    ty: Box::new(ty),
                     span,
                 });
 
@@ -119,9 +119,11 @@ where
         self.consume(TokenKind::CloseParen);
 
         let return_ty = if self.consume(TokenKind::RightArrow) {
-            Some(self.parse_ident()?)
+            let ty = self.parse_ty()?;
+
+            FnReturnTy::Ty(Box::new(ty))
         } else {
-            None
+            FnReturnTy::Unit
         };
 
         self.consume(TokenKind::OpenBrace);
@@ -158,13 +160,13 @@ where
 
                 self.consume(TokenKind::Colon);
 
-                let ty_annotation = self.parse_ident()?;
+                let ty = self.parse_ty()?;
 
                 let span = field_name.span;
 
                 fields.push(FieldDecl {
                     name: Some(field_name),
-                    ty: ty_annotation,
+                    ty: Box::new(ty),
                     span,
                 });
 

--- a/crates/crane/src/parser/stmt.rs
+++ b/crates/crane/src/parser/stmt.rs
@@ -7,6 +7,7 @@ impl<TokenStream> Parser<TokenStream>
 where
     TokenStream: Iterator<Item = Result<Token, LexError>>,
 {
+    /// Parses a [`Stmt`].
     #[tracing::instrument(skip(self))]
     pub fn parse_stmt(&mut self) -> ParseResult<Option<Stmt>> {
         if self.consume_keyword(keywords::LET) {

--- a/crates/crane/src/parser/ty.rs
+++ b/crates/crane/src/parser/ty.rs
@@ -1,0 +1,22 @@
+use crate::ast::{Ty, TyKind};
+use crate::lexer::token::Token;
+use crate::lexer::LexError;
+use crate::parser::{ParseResult, Parser};
+
+impl<TokenStream> Parser<TokenStream>
+where
+    TokenStream: Iterator<Item = Result<Token, LexError>>,
+{
+    /// Parses a [`Ty`].
+    #[tracing::instrument(skip(self))]
+    pub fn parse_ty(&mut self) -> ParseResult<Ty> {
+        let path = self.parse_path()?;
+
+        let span = path.span.clone();
+
+        Ok(Ty {
+            kind: TyKind::Path(path),
+            span,
+        })
+    }
+}

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
@@ -35,7 +35,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:
@@ -93,10 +93,21 @@ Ok:
       Fn:
         params: []
         return_ty:
-          name: String
-          span:
-            start: 122
-            end: 128
+          Ty:
+            kind:
+              Path:
+                segments:
+                  - ident:
+                      name: String
+                      span:
+                        start: 122
+                        end: 128
+                span:
+                  start: 122
+                  end: 128
+            span:
+              start: 122
+              end: 128
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
@@ -91,7 +91,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:
@@ -182,7 +182,17 @@ Ok:
                 start: 135
                 end: 136
             ty:
-              name: Uint64
+              kind:
+                Path:
+                  segments:
+                    - ident:
+                        name: Uint64
+                        span:
+                          start: 138
+                          end: 144
+                  span:
+                    start: 138
+                    end: 144
               span:
                 start: 138
                 end: 144
@@ -190,10 +200,21 @@ Ok:
               start: 135
               end: 136
         return_ty:
-          name: Uint64
-          span:
-            start: 149
-            end: 155
+          Ty:
+            kind:
+              Path:
+                segments:
+                  - ident:
+                      name: Uint64
+                      span:
+                        start: 149
+                        end: 155
+                span:
+                  start: 149
+                  end: 155
+            span:
+              start: 149
+              end: 155
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
@@ -35,7 +35,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:
@@ -97,7 +97,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:
@@ -140,7 +140,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
@@ -35,7 +35,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -91,7 +91,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Local:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@modules.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@modules.crane.snap
@@ -91,7 +91,7 @@ Ok:
   - kind:
       Fn:
         params: []
-        return_ty: ~
+        return_ty: Unit
         body:
           - kind:
               Expr:
@@ -221,10 +221,21 @@ Ok:
                               Fn:
                                 params: []
                                 return_ty:
-                                  name: Uint64
-                                  span:
-                                    start: 224
-                                    end: 230
+                                  Ty:
+                                    kind:
+                                      Path:
+                                        segments:
+                                          - ident:
+                                              name: Uint64
+                                              span:
+                                                start: 224
+                                                end: 230
+                                        span:
+                                          start: 224
+                                          end: 230
+                                    span:
+                                      start: 224
+                                      end: 230
                                 body:
                                   - kind:
                                       Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@struct_decls.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@struct_decls.crane.snap
@@ -13,7 +13,17 @@ Ok:
                 start: 19
                 end: 20
             ty:
-              name: Uint64
+              kind:
+                Path:
+                  segments:
+                    - ident:
+                        name: Uint64
+                        span:
+                          start: 22
+                          end: 28
+                  span:
+                    start: 22
+                    end: 28
               span:
                 start: 22
                 end: 28
@@ -26,7 +36,17 @@ Ok:
                 start: 34
                 end: 35
             ty:
-              name: Uint64
+              kind:
+                Path:
+                  segments:
+                    - ident:
+                        name: Uint64
+                        span:
+                          start: 37
+                          end: 43
+                  span:
+                    start: 37
+                    end: 43
               span:
                 start: 37
                 end: 43


### PR DESCRIPTION
This PR updates the AST to explicitly represent types.

Previously types were just referred to as an `Ident`, but this is too simplistic.