### PR TITLE
Add parsing for function types

### DIFF
--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -292,7 +292,7 @@ mod tests {
 
         insta::assert_snapshot!(size_of::<Expr>().to_string(), @"48");
         insta::assert_snapshot!(size_of::<ExprKind>().to_string(), @"32");
-        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"24");
+        insta::assert_snapshot!(size_of::<Fn>().to_string(), @"16");
         insta::assert_snapshot!(size_of::<Item>().to_string(), @"72");
         insta::assert_snapshot!(size_of::<ItemKind>().to_string(), @"32");
         insta::assert_snapshot!(size_of::<Stmt>().to_string(), @"32");

--- a/crates/crane/src/ast/untyped.rs
+++ b/crates/crane/src/ast/untyped.rs
@@ -19,11 +19,20 @@ pub struct PathSegment {
     pub ident: Ident,
 }
 
+/// A function type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FnTy {
+    pub decl: Box<FnDecl>,
+}
+
 /// The kind of a [`Ty`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TyKind {
     /// A type referenced by its path.
     Path(Path),
+
+    /// A function type.
+    Fn(Box<FnTy>),
 }
 
 /// A type.
@@ -128,9 +137,14 @@ pub struct UseTree {
 /// A function definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fn {
+    pub decl: Box<FnDecl>,
+    pub body: ThinVec<Stmt>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FnDecl {
     pub params: ThinVec<FnParam>,
     pub return_ty: FnReturnTy,
-    pub body: ThinVec<Stmt>,
 }
 
 /// A parameter to a [`Fn`].

--- a/crates/crane/src/ast/visitor.rs
+++ b/crates/crane/src/ast/visitor.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    Expr, ExprKind, FieldDecl, Fn, FnParam, FnReturnTy, Ident, Item, ItemKind, Local, ModuleDecl,
-    Path, PathSegment, Stmt, StmtKind, StructDecl, Ty, UnionDecl, UseTree, UseTreeKind, Variant,
-    VariantData,
+    Expr, ExprKind, FieldDecl, Fn, FnDecl, FnParam, FnReturnTy, Ident, Item, ItemKind, Local,
+    ModuleDecl, Path, PathSegment, Stmt, StmtKind, StructDecl, Ty, UnionDecl, UseTree, UseTreeKind,
+    Variant, VariantData,
 };
 
 pub trait Visitor: Sized {
@@ -27,6 +27,10 @@ pub trait Visitor: Sized {
 
     fn visit_fn(&mut self, fun: &Fn) {
         walk_fn(self, fun);
+    }
+
+    fn visit_fn_decl(&mut self, fun_decl: &FnDecl) {
+        walk_fn_decl(self, fun_decl);
     }
 
     fn visit_fn_param(&mut self, param: &FnParam) {
@@ -115,15 +119,19 @@ pub fn walk_path_segment<V: Visitor>(visitor: &mut V, path_segment: &PathSegment
 }
 
 pub fn walk_fn<V: Visitor>(visitor: &mut V, fun: &Fn) {
-    for param in &fun.params {
-        visitor.visit_fn_param(param);
-    }
-
-    visitor.visit_fn_return_ty(&fun.return_ty);
+    visitor.visit_fn_decl(&fun.decl);
 
     for stmt in &fun.body {
         visitor.visit_stmt(stmt);
     }
+}
+
+pub fn walk_fn_decl<V: Visitor>(visitor: &mut V, fun_decl: &FnDecl) {
+    for param in &fun_decl.params {
+        visitor.visit_fn_param(param);
+    }
+
+    visitor.visit_fn_return_ty(&fun_decl.return_ty);
 }
 
 pub fn walk_fn_param<V: Visitor>(visitor: &mut V, param: &FnParam) {

--- a/crates/crane/src/lexer/token.rs
+++ b/crates/crane/src/lexer/token.rs
@@ -95,6 +95,7 @@ impl Token {
         self.kind == TokenKind::Ident && self.lexeme == keyword.name
     }
 
+    /// Returns the [`Ident`] for this token, if it is one.
     pub fn ident(&self) -> Option<Ident> {
         match self.kind {
             TokenKind::Ident => Some(Ident {
@@ -103,5 +104,17 @@ impl Token {
             }),
             _ => None,
         }
+    }
+
+    /// Returns whether this token is an [`Ident`].
+    pub fn is_ident(&self) -> bool {
+        self.ident().is_some()
+    }
+
+    /// Returns whether this token is the start of a [`Path`].
+    ///
+    /// [`Path`]: crate::ast::Path
+    pub fn is_path_start(&self) -> bool {
+        self.kind == TokenKind::ColonColon || self.is_ident()
     }
 }

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -21,6 +21,7 @@ enum ExpectedToken {
     Token(TokenKind),
     Keyword(Ident),
     Ident,
+    Path,
 }
 
 impl std::fmt::Display for ExpectedToken {
@@ -32,6 +33,7 @@ impl std::fmt::Display for ExpectedToken {
                 Self::Token(kind) => format!("`{kind:?}`"),
                 Self::Keyword(keyword) => format!("`{keyword}`"),
                 Self::Ident => "an identifier".to_string(),
+                Self::Path => "a path".to_string(),
             }
         )
     }
@@ -194,6 +196,14 @@ where
         self.token.is_keyword(keyword)
     }
 
+    fn check_or_expected(&mut self, is_ok: bool, expected: ExpectedToken) -> bool {
+        if !is_ok {
+            self.expected_tokens.push(expected);
+        }
+
+        is_ok
+    }
+
     /// Consumes the next token if it is of the given [`TokenKind`].
     ///
     /// Returns whether the token was present.
@@ -231,6 +241,14 @@ where
         self.advance();
 
         Ok(ident)
+    }
+
+    /// Returns whether the next token is a [`Path`].
+    ///
+    /// If the next token is not a [`Path`] this method will add the token to the list
+    /// of expected tokens.
+    fn check_path(&mut self) -> bool {
+        self.check_or_expected(self.token.is_path_start(), ExpectedToken::Path)
     }
 
     /// Parses a [`Path`].

--- a/crates/crane/src/parser.rs
+++ b/crates/crane/src/parser.rs
@@ -243,6 +243,14 @@ where
         Ok(ident)
     }
 
+    /// Returns whether the next token is an [`Ident`].
+    ///
+    /// If the next token is not an [`Ident`] this method will add the token to the list
+    /// of expected tokens.
+    fn check_ident(&mut self) -> bool {
+        self.check_or_expected(self.token.is_ident(), ExpectedToken::Ident)
+    }
+
     /// Returns whether the next token is a [`Path`].
     ///
     /// If the next token is not a [`Path`] this method will add the token to the list

--- a/crates/crane/src/parser/item.rs
+++ b/crates/crane/src/parser/item.rs
@@ -1,8 +1,8 @@
 use thin_vec::ThinVec;
 
 use crate::ast::{
-    keywords, FieldDecl, Fn, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind, Module,
-    ModuleDecl, Path, PathSegment, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant,
+    keywords, FieldDecl, Fn, FnDecl, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind,
+    Module, ModuleDecl, Path, PathSegment, StructDecl, UnionDecl, UseTree, UseTreeKind, Variant,
     VariantData, DUMMY_SPAN,
 };
 use crate::lexer::token::{Token, TokenKind};
@@ -139,12 +139,16 @@ where
         Ok((
             ident,
             Fn {
-                params,
-                return_ty,
+                decl: Box::new(FnDecl { params, return_ty }),
                 body,
             },
         ))
     }
+
+    // #[tracing::instrument(skip(self))]
+    // fn parse_fn_decl(&mut self) -> ParseResult<(Ident, Fn)> {
+
+    // }
 
     #[tracing::instrument(skip(self))]
     fn parse_struct_decl(&mut self) -> ParseResult<(Ident, StructDecl)> {

--- a/crates/crane/src/parser/ty.rs
+++ b/crates/crane/src/parser/ty.rs
@@ -1,5 +1,7 @@
-use crate::ast::{Ty, TyKind};
-use crate::lexer::token::Token;
+use thin_vec::ThinVec;
+
+use crate::ast::{FnDecl, FnParam, FnReturnTy, FnTy, Ident, Ty, TyKind, DUMMY_SPAN};
+use crate::lexer::token::{Token, TokenKind};
 use crate::lexer::LexError;
 use crate::parser::{ParseError, ParseErrorKind, ParseResult, Parser};
 
@@ -10,6 +12,19 @@ where
     /// Parses a [`Ty`].
     #[tracing::instrument(skip(self))]
     pub fn parse_ty(&mut self) -> ParseResult<Ty> {
+        if let Some(ident) = self.token.ident() {
+            if ident.name == "Fn" {
+                let fn_ty = self.parse_fn_ty()?;
+
+                let span = ident.span.to(self.prev_token.span);
+
+                return Ok(Ty {
+                    kind: TyKind::Fn(Box::new(fn_ty)),
+                    span,
+                });
+            }
+        }
+
         if self.check_path() {
             let path = self.parse_path()?;
 
@@ -24,6 +39,50 @@ where
         Err(ParseError {
             kind: ParseErrorKind::Error("Expected a type.".to_string()),
             span: self.token.span,
+        })
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn parse_fn_ty(&mut self) -> ParseResult<FnTy> {
+        self.parse_ident()?;
+
+        self.consume(TokenKind::OpenParen);
+
+        let mut params = ThinVec::new();
+
+        if !self.check_without_expect(TokenKind::CloseParen) {
+            loop {
+                let ty = self.parse_ty()?;
+
+                let span = ty.span;
+
+                params.push(FnParam {
+                    name: Ident {
+                        name: "".into(),
+                        span: DUMMY_SPAN,
+                    },
+                    ty: Box::new(ty),
+                    span,
+                });
+
+                if !self.consume(TokenKind::Comma) {
+                    break;
+                }
+            }
+        }
+
+        self.consume(TokenKind::CloseParen);
+
+        let return_ty = if self.consume(TokenKind::RightArrow) {
+            let ty = self.parse_ty()?;
+
+            FnReturnTy::Ty(Box::new(ty))
+        } else {
+            FnReturnTy::Unit
+        };
+
+        Ok(FnTy {
+            decl: Box::new(FnDecl { params, return_ty }),
         })
     }
 }

--- a/crates/crane/src/parser/ty.rs
+++ b/crates/crane/src/parser/ty.rs
@@ -1,7 +1,7 @@
 use crate::ast::{Ty, TyKind};
 use crate::lexer::token::Token;
 use crate::lexer::LexError;
-use crate::parser::{ParseResult, Parser};
+use crate::parser::{ParseError, ParseErrorKind, ParseResult, Parser};
 
 impl<TokenStream> Parser<TokenStream>
 where
@@ -10,13 +10,20 @@ where
     /// Parses a [`Ty`].
     #[tracing::instrument(skip(self))]
     pub fn parse_ty(&mut self) -> ParseResult<Ty> {
-        let path = self.parse_path()?;
+        if self.check_path() {
+            let path = self.parse_path()?;
 
-        let span = path.span.clone();
+            let span = path.span.clone();
 
-        Ok(Ty {
-            kind: TyKind::Path(path),
-            span,
+            return Ok(Ty {
+                kind: TyKind::Path(path),
+                span,
+            });
+        }
+
+        Err(ParseError {
+            kind: ParseErrorKind::Error("Expected a type.".to_string()),
+            span: self.token.span,
         })
     }
 }

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@comments.crane.snap
@@ -34,8 +34,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:
@@ -91,23 +92,24 @@ Ok:
         end: 29
   - kind:
       Fn:
-        params: []
-        return_ty:
-          Ty:
-            kind:
-              Path:
-                segments:
-                  - ident:
-                      name: String
-                      span:
-                        start: 122
-                        end: 128
-                span:
-                  start: 122
-                  end: 128
-            span:
-              start: 122
-              end: 128
+        decl:
+          params: []
+          return_ty:
+            Ty:
+              kind:
+                Path:
+                  segments:
+                    - ident:
+                        name: String
+                        span:
+                          start: 122
+                          end: 128
+                  span:
+                    start: 122
+                    end: 128
+              span:
+                start: 122
+                end: 128
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@function_return_types.crane.snap
@@ -90,8 +90,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:
@@ -175,46 +176,47 @@ Ok:
         end: 79
   - kind:
       Fn:
-        params:
-          - name:
-              name: n
+        decl:
+          params:
+            - name:
+                name: n
+                span:
+                  start: 135
+                  end: 136
+              ty:
+                kind:
+                  Path:
+                    segments:
+                      - ident:
+                          name: Uint64
+                          span:
+                            start: 138
+                            end: 144
+                    span:
+                      start: 138
+                      end: 144
+                span:
+                  start: 138
+                  end: 144
               span:
                 start: 135
                 end: 136
-            ty:
+          return_ty:
+            Ty:
               kind:
                 Path:
                   segments:
                     - ident:
                         name: Uint64
                         span:
-                          start: 138
-                          end: 144
+                          start: 149
+                          end: 155
                   span:
-                    start: 138
-                    end: 144
+                    start: 149
+                    end: 155
               span:
-                start: 138
-                end: 144
-            span:
-              start: 135
-              end: 136
-        return_ty:
-          Ty:
-            kind:
-              Path:
-                segments:
-                  - ident:
-                      name: Uint64
-                      span:
-                        start: 149
-                        end: 155
-                span:
-                  start: 149
-                  end: 155
-            span:
-              start: 149
-              end: 155
+                start: 149
+                end: 155
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@functions.crane.snap
@@ -34,8 +34,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:
@@ -96,8 +97,9 @@ Ok:
         end: 33
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:
@@ -139,8 +141,9 @@ Ok:
         end: 87
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@hello_world.crane.snap
@@ -34,8 +34,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@let_bindings.crane.snap
@@ -90,8 +90,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Local:

--- a/crates/crane/src/snapshots/crane__parser__tests__parser@modules.crane.snap
+++ b/crates/crane/src/snapshots/crane__parser__tests__parser@modules.crane.snap
@@ -90,8 +90,9 @@ Ok:
         end: 0
   - kind:
       Fn:
-        params: []
-        return_ty: Unit
+        decl:
+          params: []
+          return_ty: Unit
         body:
           - kind:
               Expr:
@@ -219,23 +220,24 @@ Ok:
                       - items:
                           - kind:
                               Fn:
-                                params: []
-                                return_ty:
-                                  Ty:
-                                    kind:
-                                      Path:
-                                        segments:
-                                          - ident:
-                                              name: Uint64
-                                              span:
-                                                start: 224
-                                                end: 230
-                                        span:
-                                          start: 224
-                                          end: 230
-                                    span:
-                                      start: 224
-                                      end: 230
+                                decl:
+                                  params: []
+                                  return_ty:
+                                    Ty:
+                                      kind:
+                                        Path:
+                                          segments:
+                                            - ident:
+                                                name: Uint64
+                                                span:
+                                                  start: 224
+                                                  end: 230
+                                          span:
+                                            start: 224
+                                            end: 230
+                                      span:
+                                        start: 224
+                                        end: 230
                                 body:
                                   - kind:
                                       Expr:

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -292,9 +292,9 @@ impl Typer {
             match item.kind {
                 ItemKind::Use(_) => {}
                 ItemKind::Fn(ref fun) => {
-                    let typed_params = self.infer_function_params(&fun.params)?;
+                    let typed_params = self.infer_function_params(&fun.decl.params)?;
 
-                    let return_ty = match &fun.return_ty {
+                    let return_ty = match &fun.decl.return_ty {
                         FnReturnTy::Ty(ty) => match &ty.kind {
                             TyKind::Path(path) => {
                                 let (PathSegment { ident }, _) =
@@ -305,6 +305,9 @@ impl Typer {
                                     module: "std::prelude".into(),
                                     name: ident.to_string().into(),
                                 })
+                            }
+                            TyKind::Fn(fn_ty) => {
+                                todo!()
                             }
                         },
                         FnReturnTy::Unit => self.unit_ty.clone(),
@@ -492,7 +495,7 @@ impl Typer {
     fn infer_function(&mut self, path: &TyPath, fun: Fn) -> TypeCheckResult<TyFn> {
         let (_, return_ty) = self.ensure_function_exists(&path)?;
 
-        let params = self.infer_function_params(&fun.params)?;
+        let params = self.infer_function_params(&fun.decl.params)?;
 
         self.scopes
             .push(HashMap::from_iter(params.clone().into_iter().map(
@@ -560,6 +563,9 @@ impl Typer {
 
                             ident.to_string().into()
                         }
+                        TyKind::Fn(fn_ty) => {
+                            todo!()
+                        }
                     },
                 }),
                 span: param.span,
@@ -626,6 +632,9 @@ impl Typer {
                                     path.segments.split_last().unwrap();
 
                                 ident.clone()
+                            }
+                            TyKind::Fn(fn_ty) => {
+                                todo!()
                             }
                         },
                         span: field.span,

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -57,10 +57,6 @@ pub fn main() {
     println(int_to_string(add_5(7)))
 }
 
-fn do(callback: Fn(Uint64, Uint64) -> Uint64) {
-    callback(1, 2)
-}
-
 fn always_3() -> Uint64 {
     3
 }

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -57,6 +57,10 @@ pub fn main() {
     println(int_to_string(add_5(7)))
 }
 
+fn do(callback: Fn(Uint64, Uint64) -> Uint64) {
+    callback(1, 2)
+}
+
 fn always_3() -> Uint64 {
     3
 }


### PR DESCRIPTION
This PR adds support for parsing function types as parameters to functions.

```rs
fn do_add(add: Fn(Uint64, Uint64) -> Uint64, x: Uint64, y: Uint64) -> Uint64 {
    add(x, y)
}
```