### PR TITLE
Require union names to be PascalCased

### DIFF
--- a/crates/crane/src/snapshots/crane__compiler__tests__mixed_case_union_name.snap
+++ b/crates/crane/src/snapshots/crane__compiler__tests__mixed_case_union_name.snap
@@ -1,0 +1,14 @@
+---
+source: crates/crane/src/compiler.rs
+expression: "&stderr"
+---
+Error: A type error occurred.
+   ╭─[mixed_case.crane:1:2]
+   │
+ 1 │ union XMLHttpRequest {
+   │       ───────┬──────  
+   │              ╰──────── Union names must be written in PascalCase.
+   │              │        
+   │              ╰──────── Try writing it as `XmlHttpRequest` instead.
+───╯
+

--- a/crates/crane/src/snapshots/crane__compiler__tests__snake_case_union_name.snap
+++ b/crates/crane/src/snapshots/crane__compiler__tests__snake_case_union_name.snap
@@ -1,0 +1,14 @@
+---
+source: crates/crane/src/compiler.rs
+expression: "&stderr"
+---
+Error: A type error occurred.
+   ╭─[snake_case.crane:1:2]
+   │
+ 1 │ union snake_cased_union {
+   │       ────────┬────────  
+   │               ╰────────── Union names must be written in PascalCase.
+   │               │          
+   │               ╰────────── Try writing it as `SnakeCasedUnion` instead.
+───╯
+

--- a/crates/crane/src/typer/error.rs
+++ b/crates/crane/src/typer/error.rs
@@ -16,6 +16,10 @@ pub enum TypeErrorKind {
         reason: String,
         suggestion: SmolStr,
     },
+    InvalidTypeName {
+        reason: String,
+        suggestion: SmolStr,
+    },
     UnknownModule {
         path: TyPath,
         options: ThinVec<TyPath>,


### PR DESCRIPTION
This PR makes the compiler enforce that union names are written in PascalCase.