### PR TITLE
Require struct names to be PascalCased

### DIFF
--- a/crates/crane/src/compiler.rs
+++ b/crates/crane/src/compiler.rs
@@ -295,6 +295,62 @@ fn XMLHttpRequest() {}
     }
 
     #[test]
+    pub fn test_snake_case_struct_name() {
+        let mut compiler = Compiler::new();
+
+        let params = CompileParams {
+            input: Input::String {
+                filename: "snake_case.crane".into(),
+                input: r#"
+struct snake_cased_struct {
+    foo: Uint64,
+    bar: Uint64,
+}
+                "#
+                .trim()
+                .to_string(),
+            },
+        };
+
+        let mut stderr = Vec::new();
+
+        let _ = compiler.compile(&mut stderr, params);
+
+        let stderr = strip_ansi_escapes::strip(stderr).unwrap();
+        let stderr = std::str::from_utf8(&stderr).unwrap();
+
+        insta::assert_snapshot!(&stderr);
+    }
+
+    #[test]
+    pub fn test_mixed_case_struct_name() {
+        let mut compiler = Compiler::new();
+
+        let params = CompileParams {
+            input: Input::String {
+                filename: "mixed_case.crane".into(),
+                input: r#"
+struct XMLHttpRequest {
+    foo: Uint64,
+    bar: Uint64,
+}
+                "#
+                .trim()
+                .to_string(),
+            },
+        };
+
+        let mut stderr = Vec::new();
+
+        let _ = compiler.compile(&mut stderr, params);
+
+        let stderr = strip_ansi_escapes::strip(stderr).unwrap();
+        let stderr = std::str::from_utf8(&stderr).unwrap();
+
+        insta::assert_snapshot!(&stderr);
+    }
+
+    #[test]
     pub fn test_snake_case_union_name() {
         let mut compiler = Compiler::new();
 

--- a/crates/crane/src/snapshots/crane__compiler__tests__mixed_case_struct_name.snap
+++ b/crates/crane/src/snapshots/crane__compiler__tests__mixed_case_struct_name.snap
@@ -1,0 +1,14 @@
+---
+source: crates/crane/src/compiler.rs
+expression: "&stderr"
+---
+Error: A type error occurred.
+   ╭─[mixed_case.crane:1:2]
+   │
+ 1 │ struct XMLHttpRequest {
+   │        ───────┬──────  
+   │               ╰──────── Struct names must be written in PascalCase.
+   │               │        
+   │               ╰──────── Try writing it as `XmlHttpRequest` instead.
+───╯
+

--- a/crates/crane/src/snapshots/crane__compiler__tests__snake_case_struct_name.snap
+++ b/crates/crane/src/snapshots/crane__compiler__tests__snake_case_struct_name.snap
@@ -1,0 +1,14 @@
+---
+source: crates/crane/src/compiler.rs
+expression: "&stderr"
+---
+Error: A type error occurred.
+   ╭─[snake_case.crane:1:2]
+   │
+ 1 │ struct snake_cased_struct {
+   │        ─────────┬────────  
+   │                 ╰────────── Struct names must be written in PascalCase.
+   │                 │          
+   │                 ╰────────── Try writing it as `SnakeCasedStruct` instead.
+───╯
+


### PR DESCRIPTION
This PR makes the compiler enforce that struct names are written in
PascalCase.