### PR TITLE
Store Inkwell objects on `NativeBackend`

### DIFF
--- a/crates/crane/src/compiler.rs
+++ b/crates/crane/src/compiler.rs
@@ -68,7 +68,9 @@ impl Compiler {
                     Ok(typed_package) => {
                         std::fs::create_dir_all("build").unwrap();
 
-                        let backend = NativeBackend::new();
+                        let context = inkwell::context::Context::create();
+
+                        let backend = NativeBackend::new(&context);
 
                         backend.compile(typed_package);
 

--- a/examples/scratch.crane
+++ b/examples/scratch.crane
@@ -16,7 +16,7 @@ union Bool {
 pub fn main() {
     let twenty_three = 23
 
-    let user = User { name: "Jane", age: 27 }
+    // let user = User { name: "Jane", age: 27 }
 
     println("Hey")
 


### PR DESCRIPTION
This PR refactors the `NativeBackend` to store the various Inkwell objects on it rather than threading them around as parameters everywhere.

One small downside to this is that the caller needs to own the `Context` and pass it in to the `NativeBackend` constructor, but I couldn't find a could way to get around this without creating a self-referential struct. While it would be nice to come up with a solve for this, it's pretty minor at this point.