### PR TITLE
Move basic types to `TyContext`

### DIFF
--- a/crates/crane/src/compiler.rs
+++ b/crates/crane/src/compiler.rs
@@ -9,7 +9,7 @@ use crate::ast::{Module, Package, SourceSpan};
 use crate::backend::native::NativeBackend;
 use crate::lexer::Lexer;
 use crate::parser::{ParseErrorKind, Parser};
-use crate::typer::{TypeErrorKind, Typer};
+use crate::typer::{TyContext, TypeErrorKind, Typer};
 
 /// The input to the compiler.
 pub enum Input {
@@ -56,7 +56,9 @@ impl Compiler {
 
         match parser.parse() {
             Ok(items) => {
-                let mut typer = Typer::new();
+                let ty_context = TyContext::new();
+
+                let mut typer = Typer::new(&ty_context);
 
                 let module = Module { items };
 

--- a/crates/crane/src/typer/ty_context.rs
+++ b/crates/crane/src/typer/ty_context.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use smol_str::SmolStr;
+
+use crate::typer::Type;
+
+pub struct TyContext {
+    pub unit: Arc<Type>,
+    pub uint64: Arc<Type>,
+    pub string: Arc<Type>,
+}
+
+impl TyContext {
+    pub fn new() -> Self {
+        Self {
+            unit: Arc::new(Type::UserDefined {
+                module: SmolStr::new_inline("std::prelude"),
+                name: SmolStr::new_inline("()"),
+            }),
+            string: Arc::new(Type::UserDefined {
+                module: SmolStr::new_inline("std::prelude"),
+                name: SmolStr::new_inline("String"),
+            }),
+            uint64: Arc::new(Type::UserDefined {
+                module: SmolStr::new_inline("std::prelude"),
+                name: SmolStr::new_inline("Uint64"),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the basic types (`()`, `String`, and `Uint64`) to the `TyContext`.