### PR TITLE
Remove unused `Environment` struct

### DIFF
--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -1,4 +1,3 @@
-mod environment;
 mod error;
 mod ty;
 mod ty_context;

--- a/crates/crane/src/typer/environment.rs
+++ b/crates/crane/src/typer/environment.rs
@@ -1,1 +1,0 @@
-pub struct Environment {}


### PR DESCRIPTION
This PR removes the unused `Environment` struct.

I added this a while back but haven't ended up using it yet, so just going to delete it until we actually end up needing it.