### PR TITLE
Use `Ty` instead of `Arc<TyKind>`

### DIFF
--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -1,12 +1,11 @@
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
 use crate::ast::{Ident, Span};
-use crate::typer::TyKind;
+use crate::typer::Ty;
 
 /// A path.
 #[derive(Debug, Eq, Clone, Serialize, Deserialize)]
@@ -96,7 +95,7 @@ pub enum TyExprKind {
 pub struct TyExpr {
     pub kind: TyExprKind,
     pub span: Span,
-    pub ty: Arc<TyKind>,
+    pub ty: Ty,
 }
 
 /// The kind of a [`TyStmt`].
@@ -127,7 +126,7 @@ pub enum TyLocalKind {
 pub struct TyLocal {
     pub kind: TyLocalKind,
     pub name: Ident,
-    pub ty: Option<Arc<TyKind>>,
+    pub ty: Option<Ty>,
     pub span: Span,
 }
 
@@ -135,7 +134,7 @@ pub struct TyLocal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyFn {
     pub params: ThinVec<TyFnParam>,
-    pub return_ty: Arc<TyKind>,
+    pub return_ty: Ty,
     pub body: ThinVec<TyStmt>,
 
     // HACK: Adding this to the node so we don't have to recompute the path in
@@ -147,7 +146,7 @@ pub struct TyFn {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyFnParam {
     pub name: Ident,
-    pub ty: Arc<TyKind>,
+    pub ty: Ty,
     pub span: Span,
 }
 

--- a/crates/crane/src/ast/typed.rs
+++ b/crates/crane/src/ast/typed.rs
@@ -6,7 +6,7 @@ use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
 use crate::ast::{Ident, Span};
-use crate::typer::Type;
+use crate::typer::TyKind;
 
 /// A path.
 #[derive(Debug, Eq, Clone, Serialize, Deserialize)]
@@ -96,7 +96,7 @@ pub enum TyExprKind {
 pub struct TyExpr {
     pub kind: TyExprKind,
     pub span: Span,
-    pub ty: Arc<Type>,
+    pub ty: Arc<TyKind>,
 }
 
 /// The kind of a [`TyStmt`].
@@ -127,7 +127,7 @@ pub enum TyLocalKind {
 pub struct TyLocal {
     pub kind: TyLocalKind,
     pub name: Ident,
-    pub ty: Option<Arc<Type>>,
+    pub ty: Option<Arc<TyKind>>,
     pub span: Span,
 }
 
@@ -135,7 +135,7 @@ pub struct TyLocal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyFn {
     pub params: ThinVec<TyFnParam>,
-    pub return_ty: Arc<Type>,
+    pub return_ty: Arc<TyKind>,
     pub body: ThinVec<TyStmt>,
 
     // HACK: Adding this to the node so we don't have to recompute the path in
@@ -147,7 +147,7 @@ pub struct TyFn {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyFnParam {
     pub name: Ident,
-    pub ty: Arc<Type>,
+    pub ty: Arc<TyKind>,
     pub span: Span,
 }
 

--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -21,7 +21,7 @@ use crate::ast::{
     TyExpr, TyExprKind, TyFnParam, TyIntegerLiteral, TyItem, TyItemKind, TyLiteralKind,
     TyLocalKind, TyModule, TyPackage, TyPath, TyPathSegment, TyStmtKind, TyUint,
 };
-use crate::typer::Type;
+use crate::typer::TyKind;
 
 pub struct NativeBackend<'ctx> {
     context: &'ctx Context,
@@ -370,9 +370,9 @@ impl<'ctx> NativeBackend<'ctx> {
         }
     }
 
-    fn to_llvm_type(&self, ty: Arc<Type>) -> AnyTypeEnum<'ctx> {
+    fn to_llvm_type(&self, ty: Arc<TyKind>) -> AnyTypeEnum<'ctx> {
         match &*ty {
-            Type::Fn {
+            TyKind::Fn {
                 args: params,
                 return_ty,
             } => {
@@ -389,7 +389,7 @@ impl<'ctx> NativeBackend<'ctx> {
                     _ => panic!(""),
                 })
             }
-            Type::UserDefined { module, name } => match (module.as_ref(), name.as_ref()) {
+            TyKind::UserDefined { module, name } => match (module.as_ref(), name.as_ref()) {
                 ("std::prelude", "String") => self
                     .context
                     .i8_type()
@@ -418,7 +418,7 @@ impl<'ctx> NativeBackend<'ctx> {
                     .collect::<Vec<_>>();
 
                 let fn_type = match &*fun.return_ty {
-                    Type::UserDefined { module, name } => match (module.as_str(), name.as_str()) {
+                    TyKind::UserDefined { module, name } => match (module.as_str(), name.as_str()) {
                         ("std::prelude", "()") => self.context.void_type().fn_type(&params, false),
                         ("std::prelude", "Uint64") => {
                             self.context.i64_type().fn_type(&params, false)
@@ -430,7 +430,7 @@ impl<'ctx> NativeBackend<'ctx> {
                             .fn_type(&params, false),
                         (module, name) => panic!("Unknown type {}::{}", module, name),
                     },
-                    Type::Fn {
+                    TyKind::Fn {
                         args: _,
                         return_ty: _,
                     } => todo!(),
@@ -470,7 +470,7 @@ impl<'ctx> NativeBackend<'ctx> {
                             });
 
                             let ty = match &*ty.clone() {
-                                Type::UserDefined { module, name } => {
+                                TyKind::UserDefined { module, name } => {
                                     match (module.as_str(), name.as_str()) {
                                         ("std::prelude", "()") => todo!(),
                                         ("std::prelude", "Uint64") => {
@@ -486,7 +486,7 @@ impl<'ctx> NativeBackend<'ctx> {
                                         }
                                     }
                                 }
-                                Type::Fn {
+                                TyKind::Fn {
                                     args: _,
                                     return_ty: _,
                                 } => todo!(),

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -1,8 +1,8 @@
 mod error;
-mod r#type;
+mod ty;
 
 pub use error::*;
-pub use r#type::*;
+pub use ty::*;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -12,12 +12,12 @@ use smol_str::SmolStr;
 use thin_vec::{thin_vec, ThinVec};
 
 use crate::ast::{
-    Expr, ExprKind, Fn, FnDecl, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind,
+    self, Expr, ExprKind, Fn, FnDecl, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind,
     Literal, LiteralKind, Local, LocalKind, Module, ModuleDecl, Package, PathSegment, Span, Stmt,
     StmtKind, StructDecl, Ty, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral,
-    TyItem, TyItemKind, TyKind, TyLiteral, TyLiteralKind, TyLocal, TyLocalKind, TyModule,
-    TyPackage, TyPath, TyPathSegment, TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl,
-    TyVariant, TyVariantData, UnionDecl, UseTree, UseTreeKind, VariantData, DUMMY_SPAN,
+    TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyLocal, TyLocalKind, TyModule, TyPackage,
+    TyPath, TyPathSegment, TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl, TyVariant,
+    TyVariantData, UnionDecl, UseTree, UseTreeKind, VariantData, DUMMY_SPAN,
 };
 
 fn ty_to_string(ty: &Type) -> String {
@@ -489,7 +489,7 @@ impl Typer {
 
     fn infer_ty(&mut self, ty: Ty) -> TypeCheckResult<Arc<Type>> {
         Ok(match ty.kind {
-            TyKind::Path(path) => {
+            ast::TyKind::Path(path) => {
                 let (PathSegment { ident }, _) = path.segments.split_last().unwrap();
 
                 Arc::new(Type::UserDefined {
@@ -497,7 +497,7 @@ impl Typer {
                     name: ident.to_string().into(),
                 })
             }
-            TyKind::Fn(fn_ty) => {
+            ast::TyKind::Fn(fn_ty) => {
                 let (params, return_ty) = self.infer_function_decl(&fn_ty.decl)?;
 
                 Arc::new(Type::Fn {
@@ -743,13 +743,13 @@ impl Typer {
                     .map(|field| TyFieldDecl {
                         name: field.name.clone(),
                         ty: match &field.ty.kind {
-                            TyKind::Path(path) => {
+                            ast::TyKind::Path(path) => {
                                 let (PathSegment { ident }, _) =
                                     path.segments.split_last().unwrap();
 
                                 ident.clone()
                             }
-                            TyKind::Fn(fn_ty) => {
+                            ast::TyKind::Fn(fn_ty) => {
                                 todo!()
                             }
                         },

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -14,7 +14,7 @@ use thin_vec::{thin_vec, ThinVec};
 use crate::ast::{
     self, Expr, ExprKind, Fn, FnDecl, FnParam, FnReturnTy, Ident, InlineModuleDecl, Item, ItemKind,
     Literal, LiteralKind, Local, LocalKind, Module, ModuleDecl, Package, PathSegment, Span, Stmt,
-    StmtKind, StructDecl, Ty, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral,
+    StmtKind, StructDecl, TyExpr, TyExprKind, TyFieldDecl, TyFn, TyFnParam, TyIntegerLiteral,
     TyItem, TyItemKind, TyLiteral, TyLiteralKind, TyLocal, TyLocalKind, TyModule, TyPackage,
     TyPath, TyPathSegment, TyStmt, TyStmtKind, TyStructDecl, TyUint, TyUnionDecl, TyVariant,
     TyVariantData, UnionDecl, UseTree, UseTreeKind, VariantData, DUMMY_SPAN,
@@ -487,7 +487,7 @@ impl Typer {
         Ok(TyModule { items: typed_items })
     }
 
-    fn infer_ty(&mut self, ty: Ty) -> TypeCheckResult<Arc<TyKind>> {
+    fn infer_ty(&mut self, ty: ast::Ty) -> TypeCheckResult<Arc<TyKind>> {
         Ok(match ty.kind {
             ast::TyKind::Path(path) => {
                 let (PathSegment { ident }, _) = path.segments.split_last().unwrap();

--- a/crates/crane/src/typer/ty.rs
+++ b/crates/crane/src/typer/ty.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
+/// A type in the type system.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct Ty(Arc<TyKind>);
+
+/// The kind of a [`Ty`].
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum TyKind {
     /// A user-defined type.

--- a/crates/crane/src/typer/ty.rs
+++ b/crates/crane/src/typer/ty.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -7,6 +8,20 @@ use thin_vec::ThinVec;
 /// A type in the type system.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Ty(Arc<TyKind>);
+
+impl Deref for Ty {
+    type Target = TyKind;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Ty {
+    pub fn new(kind: TyKind) -> Self {
+        Self(Arc::new(kind))
+    }
+}
 
 /// The kind of a [`Ty`].
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -21,10 +36,7 @@ pub enum TyKind {
     },
 
     /// A function type.
-    Fn {
-        args: ThinVec<Arc<TyKind>>,
-        return_ty: Arc<TyKind>,
-    },
+    Fn { args: ThinVec<Ty>, return_ty: Ty },
 }
 
 #[cfg(test)]

--- a/crates/crane/src/typer/type.rs
+++ b/crates/crane/src/typer/type.rs
@@ -5,7 +5,7 @@ use smol_str::SmolStr;
 use thin_vec::ThinVec;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub enum Type {
+pub enum TyKind {
     /// A user-defined type.
     UserDefined {
         /// The module in which the type resides.
@@ -17,8 +17,8 @@ pub enum Type {
 
     /// A function type.
     Fn {
-        args: ThinVec<Arc<Type>>,
-        return_ty: Arc<Type>,
+        args: ThinVec<Arc<TyKind>>,
+        return_ty: Arc<TyKind>,
     },
 }
 
@@ -31,6 +31,6 @@ mod tests {
     fn test_type_size() {
         use std::mem::size_of;
 
-        insta::assert_snapshot!(size_of::<Type>().to_string(), @"48");
+        insta::assert_snapshot!(size_of::<TyKind>().to_string(), @"48");
     }
 }


### PR DESCRIPTION
This PR introduces `Ty` to wrap an `Arc<TyKind>`.