### PR TITLE
Explicitly represent `()` and `Uint64` in type system

### DIFF
--- a/crates/crane/src/backend/native.rs
+++ b/crates/crane/src/backend/native.rs
@@ -471,7 +471,9 @@ impl<'ctx> NativeBackend<'ctx> {
 
                             let ty = match &*ty.clone() {
                                 TyKind::Unit => todo!(),
-                                TyKind::Uint(UintTy::U64) =>  self.context.i64_type().as_basic_type_enum(),
+                                TyKind::Uint(UintTy::U64) => {
+                                    self.context.i64_type().as_basic_type_enum()
+                                }
                                 TyKind::UserDefined { module, name } => {
                                     match (module.as_str(), name.as_str()) {
                                         ("std::prelude", "String") => self

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@comments.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@comments.crane.snap
@@ -15,10 +15,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -55,10 +52,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Call:
@@ -95,10 +89,7 @@ Ok:
                       span:
                         start: 38
                         end: 45
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 38
                     end: 45

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@function_return_types.crane.snap
@@ -27,10 +27,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -67,10 +64,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Call:
@@ -102,9 +96,7 @@ Ok:
                                     ty:
                                       Fn:
                                         args:
-                                          - UserDefined:
-                                              module: "std::prelude"
-                                              name: Uint64
+                                          - Uint: U64
                                         return_ty:
                                           UserDefined:
                                             module: "std::prelude"
@@ -130,13 +122,9 @@ Ok:
                                             ty:
                                               Fn:
                                                 args:
-                                                  - UserDefined:
-                                                      module: "std::prelude"
-                                                      name: Uint64
+                                                  - Uint: U64
                                                 return_ty:
-                                                  UserDefined:
-                                                    module: "std::prelude"
-                                                    name: Uint64
+                                                  Uint: U64
                                           args:
                                             - kind:
                                                 Literal:
@@ -152,16 +140,12 @@ Ok:
                                                 start: 117
                                                 end: 118
                                               ty:
-                                                UserDefined:
-                                                  module: "std::prelude"
-                                                  name: Uint64
+                                                Uint: U64
                                       span:
                                         start: 110
                                         end: 116
                                       ty:
-                                        UserDefined:
-                                          module: "std::prelude"
-                                          name: Uint64
+                                        Uint: U64
                               span:
                                 start: 96
                                 end: 109
@@ -172,10 +156,7 @@ Ok:
                       span:
                         start: 88
                         end: 95
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 88
                     end: 95
@@ -203,16 +184,12 @@ Ok:
                       start: 135
                       end: 136
                   ty:
-                    UserDefined:
-                      module: "std::prelude"
-                      name: Uint64
+                    Uint: U64
                   span:
                     start: 135
                     end: 136
               return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: Uint64
+                Uint: U64
               body:
                 - kind:
                     Expr:
@@ -246,16 +223,10 @@ Ok:
                             ty:
                               Fn:
                                 args:
-                                  - UserDefined:
-                                      module: "std::prelude"
-                                      name: Uint64
-                                  - UserDefined:
-                                      module: "std::prelude"
-                                      name: Uint64
+                                  - Uint: U64
+                                  - Uint: U64
                                 return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: Uint64
+                                  Uint: U64
                           args:
                             - kind:
                                 Variable:
@@ -272,9 +243,7 @@ Ok:
                                 start: 170
                                 end: 171
                               ty:
-                                UserDefined:
-                                  module: "std::prelude"
-                                  name: Uint64
+                                Uint: U64
                             - kind:
                                 Literal:
                                   kind:
@@ -289,16 +258,12 @@ Ok:
                                 start: 173
                                 end: 175
                               ty:
-                                UserDefined:
-                                  module: "std::prelude"
-                                  name: Uint64
+                                Uint: U64
                       span:
                         start: 162
                         end: 169
                       ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: Uint64
+                        Uint: U64
                   span:
                     start: 162
                     end: 169

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@functions.crane.snap
@@ -15,10 +15,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -42,18 +39,12 @@ Ok:
                             ty:
                               Fn:
                                 args: []
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args: []
                       span:
                         start: 42
                         end: 51
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 42
                     end: 51
@@ -79,18 +70,12 @@ Ok:
                             ty:
                               Fn:
                                 args: []
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args: []
                       span:
                         start: 58
                         end: 69
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 58
                     end: 69
@@ -112,10 +97,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -152,10 +134,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -174,10 +153,7 @@ Ok:
                       span:
                         start: 96
                         end: 103
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 96
                     end: 103
@@ -199,10 +175,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -239,10 +212,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -261,10 +231,7 @@ Ok:
                       span:
                         start: 139
                         end: 146
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 139
                     end: 146

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@hello_world.crane.snap
@@ -15,10 +15,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -55,10 +52,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -77,10 +71,7 @@ Ok:
                       span:
                         start: 42
                         end: 49
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 42
                     end: 49

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@let_bindings.crane.snap
@@ -27,10 +27,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Local:
@@ -83,18 +80,14 @@ Ok:
                             start: 122
                             end: 125
                           ty:
-                            UserDefined:
-                              module: "std::prelude"
-                              name: Uint64
+                            Uint: U64
                       name:
                         name: gold
                         span:
                           start: 115
                           end: 119
                       ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: Uint64
+                        Uint: U64
                       span:
                         start: 115
                         end: 119
@@ -136,10 +129,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -158,10 +148,7 @@ Ok:
                       span:
                         start: 131
                         end: 136
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 131
                     end: 136
@@ -200,10 +187,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Variable:
@@ -226,10 +210,7 @@ Ok:
                       span:
                         start: 152
                         end: 157
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 152
                     end: 157
@@ -268,10 +249,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -290,10 +268,7 @@ Ok:
                       span:
                         start: 168
                         end: 175
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 168
                     end: 175
@@ -332,10 +307,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -354,10 +326,7 @@ Ok:
                       span:
                         start: 186
                         end: 191
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 186
                     end: 191
@@ -396,10 +365,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Call:
@@ -431,9 +397,7 @@ Ok:
                                     ty:
                                       Fn:
                                         args:
-                                          - UserDefined:
-                                              module: "std::prelude"
-                                              name: Uint64
+                                          - Uint: U64
                                         return_ty:
                                           UserDefined:
                                             module: "std::prelude"
@@ -454,9 +418,7 @@ Ok:
                                         start: 239
                                         end: 243
                                       ty:
-                                        UserDefined:
-                                          module: "std::prelude"
-                                          name: Uint64
+                                        Uint: U64
                               span:
                                 start: 225
                                 end: 238
@@ -467,10 +429,7 @@ Ok:
                       span:
                         start: 219
                         end: 224
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 219
                     end: 224
@@ -509,10 +468,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -531,10 +487,7 @@ Ok:
                       span:
                         start: 250
                         end: 257
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 250
                     end: 257

--- a/crates/crane/src/snapshots/crane__typer__tests__typer@modules.crane.snap
+++ b/crates/crane/src/snapshots/crane__typer__tests__typer@modules.crane.snap
@@ -27,10 +27,7 @@ Ok:
         - kind:
             Fn:
               params: []
-              return_ty:
-                UserDefined:
-                  module: "std::prelude"
-                  name: ()
+              return_ty: Unit
               body:
                 - kind:
                     Expr:
@@ -67,10 +64,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Literal:
@@ -89,10 +83,7 @@ Ok:
                       span:
                         start: 85
                         end: 90
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 85
                     end: 90
@@ -131,10 +122,7 @@ Ok:
                                   - UserDefined:
                                       module: "std::prelude"
                                       name: String
-                                return_ty:
-                                  UserDefined:
-                                    module: "std::prelude"
-                                    name: ()
+                                return_ty: Unit
                           args:
                             - kind:
                                 Call:
@@ -166,9 +154,7 @@ Ok:
                                     ty:
                                       Fn:
                                         args:
-                                          - UserDefined:
-                                              module: "std::prelude"
-                                              name: Uint64
+                                          - Uint: U64
                                         return_ty:
                                           UserDefined:
                                             module: "std::prelude"
@@ -205,17 +191,13 @@ Ok:
                                               Fn:
                                                 args: []
                                                 return_ty:
-                                                  UserDefined:
-                                                    module: "std::prelude"
-                                                    name: Uint64
+                                                  Uint: U64
                                           args: []
                                       span:
                                         start: 133
                                         end: 159
                                       ty:
-                                        UserDefined:
-                                          module: "std::prelude"
-                                          name: Uint64
+                                        Uint: U64
                               span:
                                 start: 119
                                 end: 132
@@ -226,10 +208,7 @@ Ok:
                       span:
                         start: 111
                         end: 118
-                      ty:
-                        UserDefined:
-                          module: "std::prelude"
-                          name: ()
+                      ty: Unit
                   span:
                     start: 111
                     end: 118
@@ -258,9 +237,7 @@ Ok:
                             Fn:
                               params: []
                               return_ty:
-                                UserDefined:
-                                  module: "std::prelude"
-                                  name: Uint64
+                                Uint: U64
                               body:
                                 - kind:
                                     Expr:
@@ -278,9 +255,7 @@ Ok:
                                         start: 245
                                         end: 247
                                       ty:
-                                        UserDefined:
-                                          module: "std::prelude"
-                                          name: Uint64
+                                        Uint: U64
                                   span:
                                     start: 245
                                     end: 247

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -21,6 +21,8 @@ use crate::ast::{
 
 fn ty_to_string(ty: Ty) -> String {
     match &*ty {
+        TyKind::Unit => "()".to_string(),
+        TyKind::Uint(UintTy::U64) => "Uint64".to_string(),
         TyKind::UserDefined { module, name } => {
             format!("{}::{}", module, name)
         }
@@ -51,25 +53,18 @@ pub struct Typer {
 
     // Types.
     unit_ty: Ty,
-    string_ty: Ty,
     uint64_ty: Ty,
+    string_ty: Ty,
 }
 
 impl Typer {
     pub fn new() -> Self {
-        let unit_ty = Ty::new(TyKind::UserDefined {
-            module: SmolStr::new_inline("std::prelude"),
-            name: SmolStr::new_inline("()"),
-        });
+        let unit_ty = Ty::new(TyKind::Unit);
+        let uint64_ty = Ty::new(TyKind::Uint(UintTy::U64));
 
         let string_ty = Ty::new(TyKind::UserDefined {
             module: SmolStr::new_inline("std::prelude"),
             name: SmolStr::new_inline("String"),
-        });
-
-        let uint64_ty = Ty::new(TyKind::UserDefined {
-            module: SmolStr::new_inline("std::prelude"),
-            name: SmolStr::new_inline("Uint64"),
         });
 
         Self {
@@ -77,8 +72,8 @@ impl Typer {
             use_map: HashMap::new(),
             scopes: Vec::new(),
             unit_ty,
-            string_ty,
             uint64_ty,
+            string_ty,
         }
     }
 

--- a/crates/crane/src/typer.rs
+++ b/crates/crane/src/typer.rs
@@ -483,10 +483,13 @@ impl Typer {
             ast::TyKind::Path(path) => {
                 let (PathSegment { ident }, _) = path.segments.split_last().unwrap();
 
-                Ty::new(TyKind::UserDefined {
-                    module: "std::prelude".into(),
-                    name: ident.to_string().into(),
-                })
+                match ident.name.as_str() {
+                    "Uint64" => self.uint64_ty.clone(),
+                    _ => Ty::new(TyKind::UserDefined {
+                        module: "std::prelude".into(),
+                        name: ident.to_string().into(),
+                    }),
+                }
             }
             ast::TyKind::Fn(fn_ty) => {
                 let (params, return_ty) = self.infer_function_decl(&fn_ty.decl)?;

--- a/crates/crane/src/typer/ty.rs
+++ b/crates/crane/src/typer/ty.rs
@@ -26,6 +26,15 @@ impl Ty {
 /// The kind of a [`Ty`].
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum TyKind {
+    /// The unit type (`()`).
+    Unit,
+
+    /// An unsigned integer type.
+    Uint(UintTy),
+
+    /// A function type.
+    Fn { args: ThinVec<Ty>, return_ty: Ty },
+
     /// A user-defined type.
     UserDefined {
         /// The module in which the type resides.
@@ -34,9 +43,13 @@ pub enum TyKind {
         /// The name of the type.
         name: SmolStr,
     },
+}
 
-    /// A function type.
-    Fn { args: ThinVec<Ty>, return_ty: Ty },
+/// An unsigned integer type.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub enum UintTy {
+    /// A 64-bit unsigned integer.
+    U64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR updates how `()` and `Uint64` are represented in the type system.

Previously these were both represented as `UserDefined` values.

However, we have now promoted them to top-level `TyKind`s.