### PR TITLE
Use `resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 default-members = ["crates/crane"]


### PR DESCRIPTION
This PR updates the workspace's `Cargo.toml` to use `resolver = "2"`.